### PR TITLE
Build and publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
 
       - name: Verify version matches
         run: |
-          FILE_VERSION=$(grep -oP '__version__ = "\K[^"]+' packages/common/src/handler_common/_version.py)
+          PROJECT_VERSION=$(uv version --short)
           TAG_VERSION=${{ steps.version.outputs.VERSION }}
-          if [ "$FILE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: Version mismatch! File: $FILE_VERSION, Tag: $TAG_VERSION"
+          if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: Version mismatch! Project: $PROJECT_VERSION, Tag: $TAG_VERSION"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ Use `just` for all development tasks:
 | `just get-card` | Fetch agent card (CLI) |
 | `just send` | Send message to agent (CLI) |
 | `just version` | Show current version |
+| `just bump` | Bump version (patch, minor, major) |
+| `just tag` | Create git tag for current version |
+| `just release` | Tag and push release to origin |
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ just install  # or: uv sync
 | `just get-card [url]` | Fetch agent card from URL |
 | `just send [url] [msg]` | Send message to agent |
 | `just version` | Show current version |
+| `just bump [level]` | Bump version (patch, minor, major) |
+| `just tag` | Create git tag for current version |
+| `just release` | Tag and push release to origin |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -3,24 +3,25 @@
 [![CI](https://github.com/alDuncanson/handler/actions/workflows/ci.yml/badge.svg)](https://github.com/alDuncanson/handler/actions/workflows/ci.yml)
 [![A2A Protocol](https://img.shields.io/badge/A2A_Protocol-v0.3.0-blue)](https://a2a-protocol.org/latest/)
 [![GitHub release](https://img.shields.io/github/v/release/alDuncanson/handler)](https://github.com/alDuncanson/handler/releases)
+[![PyPI version](https://img.shields.io/pypi/v/a2a-handler)](https://pypi.org/project/a2a-handler/)
 [![GitHub stars](https://img.shields.io/github/stars/alDuncanson/handler)](https://github.com/alDuncanson/handler/stargazers)
 
 An [A2A](https://a2a-protocol.org/latest/) Protocol client TUI and CLI.
 
 ![Handler TUI](./assets/handler-tui.png)
 
-## Run
+## Install
 
-This project is managed with [uv](https://docs.astral.sh/uv/), so you can run Handler in a temporary, isolated environment:
+Install with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uvx --from git+https://github.com/alDuncanson/Handler.git@v0.1.3 handler
+uv tool install a2a-handler
 ```
 
-or, install it globally:
+Or run directly without installing:
 
 ```bash
-uv tool install git+https://github.com/alDuncanson/Handler.git@v0.1.3
+uvx --from a2a-handler handler
 ```
 
 ## Use

--- a/justfile
+++ b/justfile
@@ -57,12 +57,16 @@ fix:
 
 # Show the current version
 version:
-    uvx hatch version
+    uv version
+
+# Bump version (major, minor, or patch)
+bump level="patch":
+    uv version --bump {{level}}
 
 # Create a git tag for the current version
 tag:
-    git tag "v$(uvx hatch version)"
+    git tag "v$(uv version --short)"
 
 # Tag and push the release to origin
 release: tag
-    git push origin "v$(uvx hatch version)"
+    git push origin "v$(uv version --short)"

--- a/packages/common/src/handler_common/_version.py
+++ b/packages/common/src/handler_common/_version.py
@@ -1,3 +1,0 @@
-"""Single source of truth for Handler version."""
-
-__version__ = "0.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 handler = "a2a_handler.cli:main"
 
 [build-system]
-requires = ["uv_build>=0.7,<0.8"]
+requires = ["uv_build>=0.9.15,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-handler"
-version = "0.1.3"
+version = "0.1.4"
 description = "An A2A Protocol client TUI and CLI."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,35 @@
 name = "a2a-handler"
 version = "0.1.3"
 description = "An A2A Protocol client TUI and CLI."
+readme = "README.md"
 requires-python = ">=3.11"
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Al Duncanson", email = "al@alduncanson.com" }
+]
+keywords = [
+    "a2a",
+    "a2a-protocol",
+    "agent",
+    "agent-to-agent",
+    "ai",
+    "cli",
+    "tui",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 dependencies = [
     "a2a-sdk>=0.2.5",
     "click>=8.0.0",
@@ -23,6 +51,13 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ty>=0.0.1a27",
 ]
+
+[project.urls]
+Homepage = "https://github.com/alDuncanson/handler"
+Repository = "https://github.com/alDuncanson/handler"
+Documentation = "https://github.com/alDuncanson/handler#readme"
+Issues = "https://github.com/alDuncanson/handler/issues"
+Changelog = "https://github.com/alDuncanson/handler/releases"
 
 [project.scripts]
 handler = "a2a_handler.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "a2a-handler"
-dynamic = ["version"]
+version = "0.1.3"
 description = "An A2A Protocol client TUI and CLI."
 requires-python = ">=3.11"
 dependencies = [
@@ -28,11 +28,8 @@ dev = [
 handler = "a2a_handler.cli:main"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.7,<0.8"]
+build-backend = "uv_build"
 
-[tool.hatch.version]
-path = "src/a2a_handler/_version.py"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/a2a_handler"]
+[tool.uv.build-backend]
+module-root = "src"

--- a/src/a2a_handler/__init__.py
+++ b/src/a2a_handler/__init__.py
@@ -1,6 +1,9 @@
 """Handler - A2A protocol client and TUI for agent interaction"""
 
-from a2a_handler._version import __version__
+from importlib.metadata import version
+
 from a2a_handler.tui import HandlerTUI, main
+
+__version__ = version("a2a-handler")
 
 __all__ = ["__version__", "HandlerTUI", "main"]

--- a/src/a2a_handler/_version.py
+++ b/src/a2a_handler/_version.py
@@ -1,3 +1,0 @@
-"""Single source of truth for Handler version."""
-
-__version__ = "0.1.3"

--- a/src/a2a_handler/tui.py
+++ b/src/a2a_handler/tui.py
@@ -4,7 +4,9 @@ from typing import Any
 
 import httpx
 from a2a.types import AgentCard
-from a2a_handler._version import __version__
+from importlib.metadata import version
+
+__version__ = version("a2a-handler")
 from a2a_handler.client import (
     build_http_client,
     fetch_agent_card,

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-handler"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-handler"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
This pull request updates the project's versioning and release workflow to use the `uv` tool, removes legacy version management code, and improves project metadata and documentation. The most important changes are grouped below.

**Versioning and Release Workflow Updates**

* Switched all versioning, tagging, and release commands in the `justfile` to use `uv` instead of `hatch`. This affects the `version`, `bump`, `tag`, and `release` tasks.
* Updated the GitHub Actions release workflow to verify the project version using `uv version --short` instead of parsing the version from a Python file.

**Project Metadata and Configuration**

* Set the project version directly in `pyproject.toml` and added comprehensive metadata fields (authors, license, keywords, classifiers, URLs). Switched the build backend to `uv_build` and removed legacy hatch configuration. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R33) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R55-R70)

**Codebase Cleanup**

* Removed the `_version.py` file from both `packages/common/src/handler_common/` and `src/a2a_handler/`, eliminating the old single-source-of-truth for the version string.
* Updated imports in `src/a2a_handler/__init__.py` and `src/a2a_handler/tui.py` to retrieve the version dynamically using `importlib.metadata.version("a2a-handler")`. [[1]](diffhunk://#diff-e26d50558d95d3f5153294881f24736e2845a171b29379b2f1a40a5ad068eeffL3-R8) [[2]](diffhunk://#diff-802a264b290c787b38102a4cc875464faa47860c757ae8e94bdd314ee3e71ad4L7-R9)

**Documentation Improvements**

* Added new `just` commands (`bump`, `tag`, `release`) to both `AGENTS.md` and `CONTRIBUTING.md` to document the updated development workflow. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R20-R22) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R47-R49)