### PR TITLE
Tasks and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "a2a-sdk>=0.2.5",
+    "a2a-sdk>=0.3.22",
     "click>=8.0.0",
     "rich-click>=1.8.0",
     "google-adk>=0.5.0",

--- a/src/a2a_handler/cli/_config.py
+++ b/src/a2a_handler/cli/_config.py
@@ -2,8 +2,7 @@
 
 import rich_click as click
 
-click.rich_click.USE_RICH_MARKUP = True
-click.rich_click.USE_MARKDOWN = True
+click.rich_click.TEXT_MARKUP = "markdown"
 click.rich_click.SHOW_ARGUMENTS = True
 click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
 click.rich_click.STYLE_HELPTEXT = ""

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -11,6 +11,7 @@ import httpx
 from a2a.client import A2ACardResolver, Client, ClientConfig, ClientFactory
 from a2a.types import (
     AgentCard,
+    GetTaskPushNotificationConfigParams,
     Message,
     Part,
     PushNotificationConfig,
@@ -566,3 +567,27 @@ class A2AService:
         logger.info("Setting push config for task %s: %s", task_id, webhook_url)
 
         return await client.set_task_callback(push_config)
+
+    async def get_push_config(
+        self,
+        task_id: str,
+        config_id: str | None = None,
+    ) -> TaskPushNotificationConfig:
+        """Get push notification configuration for a task.
+
+        Args:
+            task_id: ID of the task
+            config_id: Optional specific config ID to retrieve
+
+        Returns:
+            The push notification configuration
+        """
+        client = await self._get_or_create_client()
+
+        params = GetTaskPushNotificationConfigParams(
+            id=task_id,
+            push_notification_config_id=config_id,
+        )
+        logger.info("Getting push config for task %s", task_id)
+
+        return await client.get_task_callback(params)

--- a/src/a2a_handler/tui/app.py
+++ b/src/a2a_handler/tui/app.py
@@ -238,6 +238,9 @@ class HandlerTUI(App[Any]):
 
             messages_panel.add_agent_message(send_result)
 
+            if send_result.task:
+                messages_panel.update_task(send_result.task)
+
         except Exception as error:
             logger.error("Error sending message: %s", error, exc_info=True)
             messages_panel.add_system_message(f"Error: {error!s}")

--- a/src/a2a_handler/tui/app.tcss
+++ b/src/a2a_handler/tui/app.tcss
@@ -284,10 +284,32 @@ AgentMessage {
     color: $accent;
 }
 
-.task-section {
+.task-section-row {
     height: auto;
-    color: $success;
+    width: auto;
     margin-top: 1;
+}
+
+.task-section-label {
+    width: auto;
+    color: $text-muted;
+}
+
+.task-section-count {
+    width: auto;
+    color: $accent;
+}
+
+.artifact-row {
+    height: auto;
+}
+
+.artifact-number {
+    color: $text-muted;
+}
+
+.artifact-id {
+    color: $text;
 }
 
 .task-item {
@@ -298,6 +320,30 @@ AgentMessage {
 .task-preview {
     height: auto;
     color: $text-muted;
+}
+
+.history-row {
+    height: auto;
+}
+
+.history-number {
+    width: auto;
+    color: $text-muted;
+}
+
+.history-role-user {
+    width: auto;
+    color: $primary;
+}
+
+.history-role-agent {
+    width: auto;
+    color: $success;
+}
+
+.history-message {
+    width: 1fr;
+    color: $text;
 }
 
 /* Auth Panel */

--- a/src/a2a_handler/tui/app.tcss
+++ b/src/a2a_handler/tui/app.tcss
@@ -267,6 +267,13 @@ AgentMessage {
     height: auto;
 }
 
+.section-heading {
+    color: $accent;
+    text-style: bold;
+    margin-top: 1;
+    margin-bottom: 1;
+}
+
 .task-field-row {
     height: auto;
     width: auto;
@@ -284,32 +291,16 @@ AgentMessage {
     color: $accent;
 }
 
-.task-section-row {
-    height: auto;
-    width: auto;
+.artifact-id {
+    color: $text;
+    text-style: bold;
     margin-top: 1;
 }
 
-.task-section-label {
-    width: auto;
-    color: $text-muted;
-}
-
-.task-section-count {
-    width: auto;
-    color: $accent;
-}
-
-.artifact-row {
+.artifact-preview {
     height: auto;
-}
-
-.artifact-number {
     color: $text-muted;
-}
-
-.artifact-id {
-    color: $text;
+    padding-left: 2;
 }
 
 .task-item {
@@ -317,33 +308,24 @@ AgentMessage {
     color: $text;
 }
 
-.task-preview {
+.history-item {
     height: auto;
-    color: $text-muted;
-}
-
-.history-row {
-    height: auto;
-}
-
-.history-number {
-    width: auto;
-    color: $text-muted;
+    margin-top: 1;
 }
 
 .history-role-user {
-    width: auto;
     color: $primary;
+    text-style: bold;
 }
 
 .history-role-agent {
-    width: auto;
     color: $success;
+    text-style: bold;
 }
 
 .history-message {
-    width: 1fr;
     color: $text;
+    padding-left: 2;
 }
 
 /* Auth Panel */

--- a/src/a2a_handler/tui/app.tcss
+++ b/src/a2a_handler/tui/app.tcss
@@ -217,6 +217,56 @@ AgentMessage {
     overflow-y: auto;
 }
 
+/* Tasks Panel */
+#tasks-panel {
+    height: 1fr;
+}
+
+#tasks-split {
+    height: 1fr;
+    layout: horizontal;
+}
+
+#tasks-list {
+    width: 1fr;
+    height: 1fr;
+    border: none;
+    scrollbar-size: 1 1;
+}
+
+#tasks-list > ListItem {
+    padding: 0 1;
+}
+
+#tasks-list > ListItem:hover {
+    background: $surface;
+}
+
+#tasks-list > ListItem.-highlight {
+    background: $primary 30%;
+}
+
+#task-detail {
+    width: 2fr;
+    height: 1fr;
+    border-left: solid $secondary;
+    padding: 0 1;
+    scrollbar-size: 1 1;
+}
+
+#task-detail-placeholder {
+    color: $text-muted;
+}
+
+#task-detail-content {
+    height: auto;
+}
+
+#task-detail-content.hidden,
+#task-detail-placeholder.hidden {
+    display: none;
+}
+
 /* Auth Panel */
 #auth-panel {
     height: auto;

--- a/src/a2a_handler/tui/app.tcss
+++ b/src/a2a_handler/tui/app.tcss
@@ -258,13 +258,46 @@ AgentMessage {
     color: $text-muted;
 }
 
+#task-detail-content.hidden,
+#task-detail-placeholder.hidden {
+    display: none;
+}
+
 #task-detail-content {
     height: auto;
 }
 
-#task-detail-content.hidden,
-#task-detail-placeholder.hidden {
-    display: none;
+.task-field-row {
+    height: auto;
+    width: auto;
+}
+
+.task-label {
+    color: $text-muted;
+}
+
+.task-value {
+    color: $text;
+}
+
+.task-value-state {
+    color: $accent;
+}
+
+.task-section {
+    height: auto;
+    color: $success;
+    margin-top: 1;
+}
+
+.task-item {
+    height: auto;
+    color: $text;
+}
+
+.task-preview {
+    height: auto;
+    color: $text-muted;
 }
 
 /* Auth Panel */

--- a/src/a2a_handler/tui/components/__init__.py
+++ b/src/a2a_handler/tui/components/__init__.py
@@ -6,6 +6,7 @@ from .contact import ContactPanel
 from .input import InputPanel
 from .logs import LogsPanel
 from .messages import Message, MessagesPanel, TabbedMessagesPanel
+from .tasks import TasksPanel
 
 __all__ = [
     "AgentCardPanel",
@@ -16,4 +17,5 @@ __all__ = [
     "Message",
     "MessagesPanel",
     "TabbedMessagesPanel",
+    "TasksPanel",
 ]

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -147,7 +147,9 @@ class TabbedMessagesPanel(Container):
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Show/hide actions based on active tab context."""
         active = self._get_active_tab_id()
-        if action in ("scroll_down", "scroll_up", "scroll_half_down", "scroll_half_up"):
+        if action in ("scroll_down", "scroll_up"):
+            return active in ("messages-tab", "logs-tab", "tasks-tab")
+        if action in ("scroll_half_down", "scroll_half_up"):
             return active in ("messages-tab", "logs-tab")
         if action in ("scroll_left", "scroll_right"):
             return active == "logs-tab"
@@ -276,6 +278,8 @@ class TabbedMessagesPanel(Container):
             self._get_chat_container().scroll_down()
         elif active == "logs-tab":
             self._get_logs_panel().scroll_down()
+        elif active == "tasks-tab":
+            self._get_tasks_panel().action_cursor_down()
 
     def action_scroll_up(self) -> None:
         active = self._get_active_tab_id()
@@ -283,6 +287,8 @@ class TabbedMessagesPanel(Container):
             self._get_chat_container().scroll_up()
         elif active == "logs-tab":
             self._get_logs_panel().scroll_up()
+        elif active == "tasks-tab":
+            self._get_tasks_panel().action_cursor_up()
 
     def action_scroll_left(self) -> None:
         active = self._get_active_tab_id()

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -261,6 +261,7 @@ class TabbedMessagesPanel(Container):
         try:
             tabs_widget = self.query_one("#messages-tabs Tabs", Tabs)
             tabs_widget.action_previous_tab()
+            self.focus()
         except Exception:
             pass
 
@@ -269,6 +270,7 @@ class TabbedMessagesPanel(Container):
         try:
             tabs_widget = self.query_one("#messages-tabs Tabs", Tabs)
             tabs_widget.action_next_tab()
+            self.focus()
         except Exception:
             pass
 

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -14,8 +14,11 @@ from textual.widgets import Static, TabbedContent, TabPane, Tabs
 from a2a_handler.common import get_logger
 from a2a_handler.tui.components.auth import AuthPanel
 from a2a_handler.tui.components.logs import LogsPanel
+from a2a_handler.tui.components.tasks import TasksPanel
 
 if TYPE_CHECKING:
+    from a2a.types import Task
+
     from a2a_handler.auth import AuthCredentials
     from a2a_handler.service import SendResult
 
@@ -135,6 +138,8 @@ class TabbedMessagesPanel(Container):
         Binding("ctrl+right", "scroll_right", "Scroll Right", show=False),
         Binding("ctrl+d", "scroll_half_down", "½ Page ↓", show=True),
         Binding("ctrl+u", "scroll_half_up", "½ Page ↑", show=True),
+        Binding("y", "copy_task_id", "Copy ID", show=False),
+        Binding("Y", "copy_context_id", "Copy Ctx", show=False),
     ]
 
     can_focus = True
@@ -146,12 +151,16 @@ class TabbedMessagesPanel(Container):
             return active in ("messages-tab", "logs-tab")
         if action in ("scroll_left", "scroll_right"):
             return active == "logs-tab"
+        if action in ("copy_task_id", "copy_context_id"):
+            return active == "tasks-tab"
         return True
 
     def compose(self) -> ComposeResult:
         with TabbedContent(id="messages-tabs"):
             with TabPane("Messages", id="messages-tab"):
                 yield ChatScrollContainer(id="chat")
+            with TabPane("Tasks", id="tasks-tab"):
+                yield TasksPanel(id="tasks-panel")
             with TabPane("Auth", id="auth-tab"):
                 yield AuthPanel(id="auth-panel")
             with TabPane("Logs", id="logs-tab"):
@@ -175,6 +184,9 @@ class TabbedMessagesPanel(Container):
 
     def _get_auth_panel(self) -> AuthPanel:
         return self.query_one("#auth-panel", AuthPanel)
+
+    def _get_tasks_panel(self) -> TasksPanel:
+        return self.query_one("#tasks-panel", TasksPanel)
 
     def add_message(self, role: str, content: str) -> None:
         logger.debug("Adding %s message: %s", role, content[:50])
@@ -227,6 +239,16 @@ class TabbedMessagesPanel(Container):
         """Get configured authentication credentials from the auth panel."""
         auth_panel = self._get_auth_panel()
         return auth_panel.get_credentials()
+
+    def add_task(self, task: "Task") -> None:
+        """Add a task to the tasks panel."""
+        tasks_panel = self._get_tasks_panel()
+        tasks_panel.add_task(task)
+
+    def update_task(self, task: "Task") -> None:
+        """Update an existing task or add if new."""
+        tasks_panel = self._get_tasks_panel()
+        tasks_panel.update_task(task)
 
     def _get_active_tab_id(self) -> str:
         tabbed_content = self.query_one("#messages-tabs", TabbedContent)
@@ -289,3 +311,17 @@ class TabbedMessagesPanel(Container):
         elif active == "logs-tab":
             panel = self._get_logs_panel()
             panel.scroll_relative(y=-(panel.size.height // 2))
+
+    def action_copy_task_id(self) -> None:
+        """Copy the selected task ID to clipboard."""
+        active = self._get_active_tab_id()
+        if active == "tasks-tab":
+            tasks_panel = self._get_tasks_panel()
+            tasks_panel.action_copy_task_id()
+
+    def action_copy_context_id(self) -> None:
+        """Copy the selected context ID to clipboard."""
+        active = self._get_active_tab_id()
+        if active == "tasks-tab":
+            tasks_panel = self._get_tasks_panel()
+            tasks_panel.action_copy_context_id()

--- a/src/a2a_handler/tui/components/tasks.py
+++ b/src/a2a_handler/tui/components/tasks.py
@@ -1,0 +1,264 @@
+"""Tasks panel component for viewing task history and details."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.message import Message as TextualMessage
+from textual.reactive import reactive
+from textual.widgets import Label, ListItem, ListView, Static
+
+from a2a_handler.common import get_logger
+
+if TYPE_CHECKING:
+    from a2a.types import Task, TaskState
+
+logger = get_logger(__name__)
+
+
+class TaskEntry:
+    """Represents a task entry for display."""
+
+    def __init__(self, task: Task, received_at: datetime | None = None) -> None:
+        self.task = task
+        self.received_at = received_at or datetime.now()
+
+    @property
+    def task_id(self) -> str:
+        return self.task.id
+
+    @property
+    def context_id(self) -> str:
+        return self.task.context_id
+
+    @property
+    def state(self) -> TaskState | None:
+        if self.task.status:
+            return self.task.status.state
+        return None
+
+    @property
+    def state_str(self) -> str:
+        return str(self.state.value) if self.state else "unknown"
+
+
+class TaskListItem(ListItem):
+    """A single task item in the list."""
+
+    def __init__(
+        self,
+        entry: TaskEntry,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
+        self.entry = entry
+
+    def compose(self) -> ComposeResult:
+        time_str = self.entry.received_at.strftime("%H:%M:%S")
+        state_str = self.entry.state_str
+        task_id_short = self.entry.task_id[:8] if self.entry.task_id else "?"
+        yield Label(f"{time_str}  [{state_str}]  {task_id_short}...")
+
+
+class TaskDetailPanel(VerticalScroll):
+    """Panel showing detailed information about the selected task."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("Select a task to view details", id="task-detail-placeholder")
+        yield Static("", id="task-detail-content", classes="hidden")
+
+    def show_task(self, entry: TaskEntry | None) -> None:
+        placeholder = self.query_one("#task-detail-placeholder", Static)
+        content = self.query_one("#task-detail-content", Static)
+
+        if entry is None:
+            placeholder.remove_class("hidden")
+            content.add_class("hidden")
+            return
+
+        placeholder.add_class("hidden")
+        content.remove_class("hidden")
+
+        task = entry.task
+        lines = [
+            f"[b]Task ID:[/b] {task.id}",
+            f"[b]Context ID:[/b] {task.context_id}",
+            f"[b]State:[/b] {entry.state_str}",
+            f"[b]Received:[/b] {entry.received_at.strftime('%Y-%m-%d %H:%M:%S')}",
+        ]
+
+        if task.status:
+            if task.status.timestamp:
+                lines.append(f"[b]Last Updated:[/b] {task.status.timestamp}")
+            if task.status.message:
+                msg = task.status.message
+                if hasattr(msg, "parts") and msg.parts:
+                    from a2a_handler.service import extract_text_from_message_parts
+
+                    text = extract_text_from_message_parts(msg.parts)
+                    if text:
+                        lines.append(f"[b]Status Message:[/b] {text[:200]}")
+
+        if task.artifacts:
+            lines.append("")
+            lines.append(f"[b]Artifacts:[/b] {len(task.artifacts)}")
+            for i, artifact in enumerate(task.artifacts):
+                artifact_id = artifact.artifact_id or f"artifact-{i}"
+                lines.append(f"  • {artifact_id}")
+                if artifact.parts:
+                    from a2a_handler.service import extract_text_from_message_parts
+
+                    text = extract_text_from_message_parts(artifact.parts)
+                    if text:
+                        preview = text[:100].replace("\n", " ")
+                        if len(text) > 100:
+                            preview += "..."
+                        lines.append(f"    {preview}")
+
+        if task.history:
+            lines.append("")
+            lines.append(f"[b]History:[/b] {len(task.history)} messages")
+
+        content.update("\n".join(lines))
+
+
+class TasksPanel(Container):
+    """Panel with split view: task list on left, details on right."""
+
+    BINDINGS = [
+        Binding("j", "cursor_down", "↓ Select", show=True, key_display="j/↓"),
+        Binding("k", "cursor_up", "↑ Select", show=True, key_display="k/↑"),
+        Binding("down", "cursor_down", "Down", show=False),
+        Binding("up", "cursor_up", "Up", show=False),
+        Binding("enter", "select_task", "View", show=True),
+        Binding("y", "copy_task_id", "Copy ID", show=True),
+        Binding("Y", "copy_context_id", "Copy Ctx", show=True),
+    ]
+
+    can_focus = True
+
+    selected_index: reactive[int] = reactive(0)
+    _tasks: list[TaskEntry] = []
+
+    class TaskSelected(TextualMessage):
+        """Posted when a task is selected."""
+
+        def __init__(self, entry: TaskEntry) -> None:
+            super().__init__()
+            self.entry = entry
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="tasks-split"):
+            yield ListView(id="tasks-list")
+            yield TaskDetailPanel(id="task-detail")
+
+    def on_mount(self) -> None:
+        self._tasks = []
+        logger.debug("Tasks panel mounted")
+
+    def _get_list_view(self) -> ListView:
+        return self.query_one("#tasks-list", ListView)
+
+    def _get_detail_panel(self) -> TaskDetailPanel:
+        return self.query_one("#task-detail", TaskDetailPanel)
+
+    def add_task(self, task: Task) -> None:
+        """Add a task to the list."""
+        entry = TaskEntry(task)
+        self._tasks.insert(0, entry)
+        list_view = self._get_list_view()
+        list_view.insert(0, [TaskListItem(entry)])
+        logger.debug("Added task %s to tasks panel", task.id[:8])
+
+        if len(self._tasks) == 1:
+            self._update_detail()
+
+    def update_task(self, task: Task) -> None:
+        """Update an existing task or add if new."""
+        for i, entry in enumerate(self._tasks):
+            if entry.task_id == task.id:
+                self._tasks[i] = TaskEntry(task, entry.received_at)
+                list_view = self._get_list_view()
+                children = list(list_view.children)
+                if i < len(children):
+                    old_item = children[i]
+                    new_item = TaskListItem(self._tasks[i])
+                    old_item.remove()
+                    list_view.insert(i, [new_item])
+
+                if i == self.selected_index:
+                    self._update_detail()
+                logger.debug("Updated task %s", task.id[:8])
+                return
+
+        self.add_task(task)
+
+    def _update_detail(self) -> None:
+        """Update the detail panel with the currently selected task."""
+        detail = self._get_detail_panel()
+        if 0 <= self.selected_index < len(self._tasks):
+            detail.show_task(self._tasks[self.selected_index])
+        else:
+            detail.show_task(None)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Handle list item selection."""
+        list_view = self._get_list_view()
+        if event.item and event.item in list_view.children:
+            self.selected_index = list_view.children.index(event.item)
+            self._update_detail()
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        """Handle list item highlight (cursor movement)."""
+        list_view = self._get_list_view()
+        if event.item and event.item in list_view.children:
+            self.selected_index = list_view.children.index(event.item)
+            self._update_detail()
+
+    def action_cursor_down(self) -> None:
+        list_view = self._get_list_view()
+        list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        list_view = self._get_list_view()
+        list_view.action_cursor_up()
+
+    def action_select_task(self) -> None:
+        list_view = self._get_list_view()
+        list_view.action_select_cursor()
+
+    def action_copy_task_id(self) -> None:
+        """Copy the selected task ID to clipboard."""
+        if 0 <= self.selected_index < len(self._tasks):
+            task_id = self._tasks[self.selected_index].task_id
+            self.app.copy_to_clipboard(task_id)
+            self.notify(f"Copied task ID: {task_id[:16]}...")
+
+    def action_copy_context_id(self) -> None:
+        """Copy the selected context ID to clipboard."""
+        if 0 <= self.selected_index < len(self._tasks):
+            context_id = self._tasks[self.selected_index].context_id
+            self.app.copy_to_clipboard(context_id)
+            self.notify(f"Copied context ID: {context_id[:16]}...")
+
+    def get_selected_task(self) -> TaskEntry | None:
+        """Get the currently selected task entry."""
+        if 0 <= self.selected_index < len(self._tasks):
+            return self._tasks[self.selected_index]
+        return None
+
+    def clear(self) -> None:
+        """Clear all tasks."""
+        self._tasks = []
+        list_view = self._get_list_view()
+        list_view.clear()
+        self._update_detail()
+        logger.info("Cleared tasks panel")

--- a/src/a2a_handler/tui/components/tasks.py
+++ b/src/a2a_handler/tui/components/tasks.py
@@ -143,7 +143,7 @@ class TasksPanel(Container):
         Binding("Y", "copy_context_id", "Copy Ctx", show=True),
     ]
 
-    can_focus = True
+    can_focus = False
 
     selected_index: reactive[int] = reactive(0)
     _tasks: list[TaskEntry] = []
@@ -162,6 +162,8 @@ class TasksPanel(Container):
 
     def on_mount(self) -> None:
         self._tasks = []
+        for widget in self.query("ListView, TaskDetailPanel"):
+            widget.can_focus = False
         logger.debug("Tasks panel mounted")
 
     def _get_list_view(self) -> ListView:

--- a/src/a2a_handler/tui/components/tasks.py
+++ b/src/a2a_handler/tui/components/tasks.py
@@ -86,6 +86,10 @@ class TaskDetailPanel(VerticalScroll):
             classes="task-field-row",
         )
 
+    def _section_heading(self, title: str) -> Static:
+        """Create a section heading."""
+        return Static(title, classes="section-heading")
+
     def show_task(self, entry: TaskEntry | None) -> None:
         placeholder = self.query_one("#task-detail-placeholder", Static)
         content = self.query_one("#task-detail-content", Container)
@@ -101,6 +105,7 @@ class TaskDetailPanel(VerticalScroll):
 
         task = entry.task
 
+        content.mount(self._section_heading("Metadata"))
         content.mount(
             self._field("Task ID", task.id),
             self._field("Context ID", task.context_id),
@@ -121,22 +126,10 @@ class TaskDetailPanel(VerticalScroll):
                         content.mount(self._field("Status Message", text[:200]))
 
         if task.artifacts:
-            content.mount(
-                Horizontal(
-                    Static("Artifacts: ", classes="task-section-label"),
-                    Static(str(len(task.artifacts)), classes="task-section-count"),
-                    classes="task-section-row",
-                )
-            )
-            for i, artifact in enumerate(task.artifacts):
-                artifact_id = artifact.artifact_id or f"artifact-{i}"
-                content.mount(
-                    Horizontal(
-                        Static(f"{i + 1}. ", classes="artifact-number"),
-                        Static(artifact_id, classes="artifact-id"),
-                        classes="artifact-row",
-                    )
-                )
+            content.mount(self._section_heading("Artifacts"))
+            for artifact in task.artifacts:
+                artifact_id = artifact.artifact_id or "unnamed"
+                content.mount(Static(artifact_id, classes="artifact-id"))
                 if artifact.parts:
                     from a2a_handler.service import extract_text_from_message_parts
 
@@ -145,7 +138,7 @@ class TaskDetailPanel(VerticalScroll):
                         preview = text[:100].replace("\n", " ")
                         if len(text) > 100:
                             preview += "..."
-                        content.mount(Static(f"    {preview}", classes="task-preview"))
+                        content.mount(Static(preview, classes="artifact-preview"))
 
                 raw_json = json.dumps(artifact.model_dump(), indent=2, default=str)
                 content.mount(
@@ -157,14 +150,8 @@ class TaskDetailPanel(VerticalScroll):
                 )
 
         if task.history:
-            content.mount(
-                Horizontal(
-                    Static("Message history: ", classes="task-section-label"),
-                    Static(str(len(task.history)), classes="task-section-count"),
-                    classes="task-section-row",
-                )
-            )
-            for i, message in enumerate(task.history):
+            content.mount(self._section_heading("Messages"))
+            for message in task.history:
                 role_value = (
                     message.role.value
                     if hasattr(message.role, "value")
@@ -189,11 +176,10 @@ class TaskDetailPanel(VerticalScroll):
                             preview += "..."
 
                 content.mount(
-                    Horizontal(
-                        Static(f"{i + 1}. ", classes="history-number"),
-                        Static(f"{role_value}: ", classes=role_class),
+                    Container(
+                        Static(role_value, classes=role_class),
                         Static(preview, classes="history-message"),
-                        classes="history-row",
+                        classes="history-item",
                     )
                 )
 

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,0 +1,165 @@
+"""Tests for CLI auth commands."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from a2a_handler.cli.auth import auth
+from a2a_handler.auth import AuthType, create_bearer_auth, create_api_key_auth
+from a2a_handler.session import SessionStore
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_session_store():
+    """Create a temporary session store for testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = SessionStore(session_directory=Path(temp_dir))
+        yield store
+
+
+class TestAuthSet:
+    """Tests for auth set command."""
+
+    def test_set_bearer_token(self, runner, temp_session_store):
+        """Test setting a bearer token."""
+        with patch("a2a_handler.cli.auth.set_credentials") as mock_set:
+            result = runner.invoke(
+                auth,
+                ["set", "http://localhost:8000", "--bearer", "my-secret-token"],
+            )
+
+            assert result.exit_code == 0
+            assert "Bearer token" in result.output
+            mock_set.assert_called_once()
+            call_args = mock_set.call_args
+            assert call_args[0][0] == "http://localhost:8000"
+            assert call_args[0][1].auth_type == AuthType.BEARER
+            assert call_args[0][1].value == "my-secret-token"
+
+    def test_set_api_key(self, runner, temp_session_store):
+        """Test setting an API key."""
+        with patch("a2a_handler.cli.auth.set_credentials") as mock_set:
+            result = runner.invoke(
+                auth,
+                ["set", "http://localhost:8000", "--api-key", "my-api-key"],
+            )
+
+            assert result.exit_code == 0
+            assert "API key" in result.output
+            mock_set.assert_called_once()
+            call_args = mock_set.call_args
+            assert call_args[0][1].auth_type == AuthType.API_KEY
+            assert call_args[0][1].value == "my-api-key"
+
+    def test_set_api_key_with_custom_header(self, runner):
+        """Test setting an API key with custom header."""
+        with patch("a2a_handler.cli.auth.set_credentials") as mock_set:
+            result = runner.invoke(
+                auth,
+                [
+                    "set",
+                    "http://localhost:8000",
+                    "--api-key",
+                    "my-api-key",
+                    "--api-key-header",
+                    "X-Custom-Key",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "X-Custom-Key" in result.output
+            call_args = mock_set.call_args
+            assert call_args[0][1].header_name == "X-Custom-Key"
+
+    def test_set_both_bearer_and_api_key_fails(self, runner):
+        """Test that providing both bearer and API key fails."""
+        result = runner.invoke(
+            auth,
+            [
+                "set",
+                "http://localhost:8000",
+                "--bearer",
+                "token",
+                "--api-key",
+                "key",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "not both" in result.output.lower() or "either" in result.output.lower()
+
+    def test_set_neither_bearer_nor_api_key_fails(self, runner):
+        """Test that providing neither bearer nor API key fails."""
+        result = runner.invoke(auth, ["set", "http://localhost:8000"])
+
+        assert result.exit_code == 1
+
+
+class TestAuthShow:
+    """Tests for auth show command."""
+
+    def test_show_bearer_credentials(self, runner):
+        """Test showing bearer credentials."""
+        mock_creds = create_bearer_auth("my-secret-token-value")
+
+        with patch("a2a_handler.cli.auth.get_credentials", return_value=mock_creds):
+            result = runner.invoke(auth, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "bearer" in result.output.lower()
+            # Check that value is masked
+            assert "my-s" in result.output
+            assert "alue" in result.output
+            assert "my-secret-token-value" not in result.output
+
+    def test_show_api_key_credentials(self, runner):
+        """Test showing API key credentials."""
+        mock_creds = create_api_key_auth("my-api-key-value", header_name="X-Custom")
+
+        with patch("a2a_handler.cli.auth.get_credentials", return_value=mock_creds):
+            result = runner.invoke(auth, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "api_key" in result.output.lower()
+            assert "X-Custom" in result.output
+
+    def test_show_no_credentials(self, runner):
+        """Test showing when no credentials exist."""
+        with patch("a2a_handler.cli.auth.get_credentials", return_value=None):
+            result = runner.invoke(auth, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "No credentials" in result.output
+
+    def test_show_short_credentials_masked(self, runner):
+        """Test that short credentials are fully masked."""
+        mock_creds = create_bearer_auth("short")
+
+        with patch("a2a_handler.cli.auth.get_credentials", return_value=mock_creds):
+            result = runner.invoke(auth, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "****" in result.output
+            assert "short" not in result.output
+
+
+class TestAuthClear:
+    """Tests for auth clear command."""
+
+    def test_clear_credentials(self, runner):
+        """Test clearing credentials."""
+        with patch("a2a_handler.cli.auth.clear_credentials") as mock_clear:
+            result = runner.invoke(auth, ["clear", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "Cleared" in result.output
+            mock_clear.assert_called_once_with("http://localhost:8000")

--- a/tests/test_cli_card.py
+++ b/tests/test_cli_card.py
@@ -1,0 +1,237 @@
+"""Tests for CLI card commands."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+from a2a.types import AgentCard, AgentSkill, AgentCapabilities
+
+from a2a_handler.cli.card import card, _format_agent_card, _format_validation_result
+from a2a_handler.common import Output
+from a2a_handler.validation import ValidationResult, ValidationIssue, ValidationSource
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+def _make_agent_card() -> AgentCard:
+    """Create a test agent card."""
+    return AgentCard(
+        name="Test Agent",
+        description="A test agent",
+        url="http://localhost:8000",
+        version="1.0.0",
+        capabilities=AgentCapabilities(),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[
+            AgentSkill(
+                id="test_skill",
+                name="Test Skill",
+                description="A test skill",
+                tags=["test"],
+            )
+        ],
+    )
+
+
+class TestCardGet:
+    """Tests for card get command."""
+
+    def test_card_get_success(self, runner):
+        """Test successful card get command."""
+        mock_card = _make_agent_card()
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_card.return_value = mock_card
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(card, ["get", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "Test Agent" in result.output
+            assert "test_skill" in result.output
+
+    def test_card_get_connection_error(self, runner):
+        """Test card get handles connection errors."""
+        import httpx
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_card.side_effect = httpx.ConnectError("Connection refused")
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(card, ["get", "http://localhost:8000"])
+
+            assert result.exit_code == 1
+
+
+class TestCardValidate:
+    """Tests for card validate command."""
+
+    def test_validate_valid_file(self, runner):
+        """Test validating a valid card file."""
+        card_data = {
+            "name": "Test Agent",
+            "description": "A test agent",
+            "url": "http://localhost:8000",
+            "version": "1.0.0",
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [
+                {
+                    "id": "test",
+                    "name": "Test",
+                    "description": "Test skill",
+                    "tags": ["test"],
+                }
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(card_data, f)
+            f.flush()
+
+            result = runner.invoke(card, ["validate", f.name])
+
+            assert result.exit_code == 0
+            assert "Valid" in result.output
+
+            Path(f.name).unlink()
+
+    def test_validate_invalid_file(self, runner):
+        """Test validating an invalid card file."""
+        card_data = {"name": "Test Agent"}  # Missing required fields
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(card_data, f)
+            f.flush()
+
+            result = runner.invoke(card, ["validate", f.name])
+
+            assert result.exit_code == 1
+            assert "Invalid" in result.output
+
+            Path(f.name).unlink()
+
+    def test_validate_nonexistent_file(self, runner):
+        """Test validating a nonexistent file."""
+        result = runner.invoke(card, ["validate", "/nonexistent/path/agent.json"])
+
+        assert result.exit_code == 1
+
+    def test_validate_url(self, runner):
+        """Test validating a card from URL."""
+        mock_result = ValidationResult(
+            valid=True,
+            source="http://localhost:8000/.well-known/agent.json",
+            source_type=ValidationSource.URL,
+            agent_card=_make_agent_card(),
+        )
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.validate_agent_card_from_url") as mock_validate,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_validate.return_value = mock_result
+
+            result = runner.invoke(card, ["validate", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "Valid" in result.output
+
+
+class TestFormatAgentCard:
+    """Tests for _format_agent_card helper."""
+
+    def test_format_agent_card(self):
+        """Test formatting an agent card."""
+        mock_card = _make_agent_card()
+        output = MagicMock(spec=Output)
+
+        _format_agent_card(mock_card, output)
+
+        output.line.assert_called_once()
+        # Verify the output contains JSON
+        call_args = output.line.call_args[0][0]
+        parsed = json.loads(call_args)
+        assert parsed["name"] == "Test Agent"
+
+    def test_format_non_agent_card(self):
+        """Test formatting when not an AgentCard type."""
+        output = MagicMock(spec=Output)
+
+        _format_agent_card({"name": "raw dict"}, output)
+
+        output.line.assert_called_once()
+        call_args = output.line.call_args[0][0]
+        assert call_args == "{}"
+
+
+class TestFormatValidationResult:
+    """Tests for _format_validation_result helper."""
+
+    def test_format_valid_result(self):
+        """Test formatting a valid result."""
+        mock_result = ValidationResult(
+            valid=True,
+            source="test.json",
+            source_type=ValidationSource.FILE,
+            agent_card=_make_agent_card(),
+        )
+        output = MagicMock(spec=Output)
+
+        _format_validation_result(mock_result, output)
+
+        output.success.assert_called_once_with("Valid Agent Card")
+        output.field.assert_any_call("Agent", "Test Agent")
+
+    def test_format_invalid_result(self):
+        """Test formatting an invalid result."""
+        mock_result = ValidationResult(
+            valid=False,
+            source="test.json",
+            source_type=ValidationSource.FILE,
+            issues=[
+                ValidationIssue(
+                    field_name="url",
+                    message="Missing required field",
+                    issue_type="validation_error",
+                )
+            ],
+        )
+        output = MagicMock(spec=Output)
+
+        _format_validation_result(mock_result, output)
+
+        output.error.assert_called_once_with("Invalid Agent Card")
+        output.list_item.assert_called()

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,140 @@
+"""Tests for CLI helper functions."""
+
+from unittest.mock import MagicMock
+
+import httpx
+from a2a.client.errors import (
+    A2AClientError,
+    A2AClientHTTPError,
+    A2AClientTimeoutError,
+)
+
+from a2a_handler.cli._helpers import build_http_client, handle_client_error, TIMEOUT
+from a2a_handler.common import Output
+
+
+class TestBuildHttpClient:
+    """Tests for build_http_client function."""
+
+    def test_returns_async_client(self):
+        """Test that build_http_client returns an AsyncClient."""
+        client = build_http_client()
+        assert isinstance(client, httpx.AsyncClient)
+
+    def test_default_timeout(self):
+        """Test default timeout is applied."""
+        client = build_http_client()
+        assert client.timeout.connect == TIMEOUT
+        assert client.timeout.read == TIMEOUT
+        assert client.timeout.write == TIMEOUT
+
+    def test_custom_timeout(self):
+        """Test custom timeout is applied."""
+        client = build_http_client(timeout=60)
+        assert client.timeout.connect == 60
+        assert client.timeout.read == 60
+
+
+class TestHandleClientError:
+    """Tests for handle_client_error function."""
+
+    def test_timeout_error(self):
+        """Test handling A2AClientTimeoutError."""
+        output = MagicMock(spec=Output)
+        error = A2AClientTimeoutError("Request timed out")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "timed out" in call_args.lower()
+
+    def test_http_error_connection(self):
+        """Test handling A2AClientHTTPError with connection issue."""
+        output = MagicMock(spec=Output)
+        error = A2AClientHTTPError(500, "Connection refused")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "Connection failed" in call_args or "Connection refused" in call_args
+
+    def test_http_error_other(self):
+        """Test handling A2AClientHTTPError with other issue."""
+        output = MagicMock(spec=Output)
+        error = A2AClientHTTPError(400, "Some HTTP error")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "Some HTTP error" in call_args
+
+    def test_generic_a2a_client_error(self):
+        """Test handling generic A2AClientError."""
+        output = MagicMock(spec=Output)
+        error = A2AClientError("Generic A2A error")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "Generic A2A error" in call_args
+
+    def test_httpx_connect_error(self):
+        """Test handling httpx.ConnectError."""
+        output = MagicMock(spec=Output)
+        error = httpx.ConnectError("Connection refused")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "Connection refused" in call_args
+
+    def test_httpx_timeout_error(self):
+        """Test handling httpx.TimeoutException."""
+        output = MagicMock(spec=Output)
+        error = httpx.TimeoutException("Request timed out")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "timed out" in call_args.lower()
+
+    def test_httpx_status_error(self):
+        """Test handling httpx.HTTPStatusError."""
+        output = MagicMock(spec=Output)
+        request = httpx.Request("GET", "http://localhost:8000")
+        response = httpx.Response(404, text="Not Found", request=request)
+        error = httpx.HTTPStatusError(
+            "404 Not Found", request=request, response=response
+        )
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "404" in call_args
+
+    def test_generic_exception(self):
+        """Test handling generic exceptions."""
+        output = MagicMock(spec=Output)
+        error = ValueError("Something went wrong")
+
+        handle_client_error(error, "http://localhost:8000", output)
+
+        output.error.assert_called_once()
+        call_args = output.error.call_args[0][0]
+        assert "Something went wrong" in call_args
+
+    def test_no_output_falls_back_to_echo(self, capsys):
+        """Test that when output is None, it falls back to click.echo."""
+        error = ValueError("Error without output")
+
+        handle_client_error(error, "http://localhost:8000", None)
+
+        captured = capsys.readouterr()
+        assert "Error without output" in captured.err

--- a/tests/test_cli_message.py
+++ b/tests/test_cli_message.py
@@ -1,0 +1,360 @@
+"""Tests for CLI message commands."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from a2a.types import Task, TaskState, TaskStatus
+
+from a2a_handler.cli.message import message, _format_send_result, _stream_message
+from a2a_handler.common import Output
+from a2a_handler.service import SendResult, StreamEvent
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+def _make_task(
+    state: TaskState = TaskState.completed,
+    task_id: str = "task-123",
+    context_id: str = "ctx-123",
+) -> Task:
+    """Helper to create a Task with the given state."""
+    return Task(
+        id=task_id,
+        context_id=context_id,
+        status=TaskStatus(state=state),
+    )
+
+
+class TestMessageSend:
+    """Tests for message send command."""
+
+    def test_message_send_success(self, runner):
+        """Test successful message send."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = SendResult(task=mock_task, text="Response text")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message, ["send", "http://localhost:8000", "Hello agent"]
+            )
+
+            assert result.exit_code == 0
+            assert "Response text" in result.output
+
+    def test_message_send_with_context_id(self, runner):
+        """Test message send with context ID."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = SendResult(task=mock_task, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                [
+                    "send",
+                    "http://localhost:8000",
+                    "Hello",
+                    "--context-id",
+                    "ctx-456",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_service.send.assert_called_once_with("Hello", "ctx-456", None)
+
+    def test_message_send_with_continue_flag(self, runner):
+        """Test message send with --continue flag uses session."""
+        from a2a_handler.session import AgentSession
+
+        mock_session = AgentSession(
+            agent_url="http://localhost:8000",
+            context_id="saved-ctx",
+            task_id="saved-task",
+        )
+        mock_task = _make_task(TaskState.completed)
+        mock_result = SendResult(task=mock_task, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.get_session", return_value=mock_session),
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                ["send", "http://localhost:8000", "Hello", "--continue"],
+            )
+
+            assert result.exit_code == 0
+            mock_service.send.assert_called_once_with("Hello", "saved-ctx", None)
+
+    def test_message_send_with_bearer_auth(self, runner):
+        """Test message send with bearer token."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = SendResult(task=mock_task, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                [
+                    "send",
+                    "http://localhost:8000",
+                    "Hello",
+                    "--bearer",
+                    "my-token",
+                ],
+            )
+
+            assert result.exit_code == 0
+            call_kwargs = mock_service_cls.call_args.kwargs
+            assert call_kwargs["credentials"] is not None
+
+    def test_message_send_with_push_url(self, runner):
+        """Test message send with push notification URL."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = SendResult(task=mock_task, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                [
+                    "send",
+                    "http://localhost:8000",
+                    "Hello",
+                    "--push-url",
+                    "http://webhook.example.com",
+                ],
+            )
+
+            assert result.exit_code == 0
+            call_kwargs = mock_service_cls.call_args.kwargs
+            assert call_kwargs["push_notification_url"] == "http://webhook.example.com"
+
+    def test_message_send_connection_error(self, runner):
+        """Test message send handles connection errors."""
+        import httpx
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.side_effect = httpx.ConnectError("Connection refused")
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(message, ["send", "http://localhost:8000", "Hello"])
+
+            assert result.exit_code == 1
+
+
+class TestMessageStream:
+    """Tests for message stream command."""
+
+    def test_message_stream_invokes_send_with_stream_flag(self, runner):
+        """Test message stream command invokes send with stream=True."""
+        mock_task = _make_task(TaskState.completed)
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            async def mock_stream(*args, **kwargs):
+                yield StreamEvent(
+                    event_type="artifact",
+                    text="Chunk 1",
+                    task=mock_task,
+                )
+                yield StreamEvent(
+                    event_type="status",
+                    task=mock_task,
+                )
+
+            mock_service = MagicMock()
+            mock_service.stream = mock_stream
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message, ["stream", "http://localhost:8000", "Hello"]
+            )
+
+            assert result.exit_code == 0
+            call_kwargs = mock_service_cls.call_args.kwargs
+            assert call_kwargs["enable_streaming"] is True
+
+
+class TestFormatSendResult:
+    """Tests for _format_send_result helper."""
+
+    def test_format_completed_result(self):
+        """Test formatting a completed result with text."""
+        mock_task = _make_task(TaskState.completed, context_id="ctx-123")
+        result = SendResult(task=mock_task, text="Response text here")
+        output = MagicMock(spec=Output)
+
+        _format_send_result(result, output)
+
+        output.field.assert_any_call("Context ID", "ctx-123", dim_value=True)
+        output.state.assert_called_with("State", "completed")
+        output.markdown.assert_called_with("Response text here")
+
+    def test_format_auth_required_result(self):
+        """Test formatting an auth_required result."""
+        mock_task = _make_task(TaskState.auth_required)
+        result = SendResult(task=mock_task)
+        output = MagicMock(spec=Output)
+
+        _format_send_result(result, output)
+
+        output.warning.assert_called_with("Authentication required")
+
+    def test_format_no_text_result(self):
+        """Test formatting a result without text."""
+        mock_task = _make_task(TaskState.completed)
+        result = SendResult(task=mock_task, text="")
+        output = MagicMock(spec=Output)
+
+        _format_send_result(result, output)
+
+        output.dim.assert_called_with("No text content in response")
+
+
+class TestStreamMessage:
+    """Tests for _stream_message helper."""
+
+    @pytest.mark.asyncio
+    async def test_stream_message_collects_text(self):
+        """Test _stream_message collects and outputs text."""
+        mock_task = _make_task(TaskState.completed)
+
+        async def mock_stream(*args, **kwargs):
+            yield StreamEvent(
+                event_type="artifact",
+                text="First chunk",
+                task=mock_task,
+            )
+            yield StreamEvent(
+                event_type="artifact",
+                text="Second chunk",
+                task=mock_task,
+            )
+
+        mock_service = MagicMock()
+        mock_service.stream = mock_stream
+
+        output = MagicMock(spec=Output)
+
+        with patch("a2a_handler.cli.message.update_session"):
+            await _stream_message(
+                mock_service,
+                "Hello",
+                None,
+                None,
+                "http://localhost:8000",
+                output,
+            )
+
+        assert output.line.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_message_shows_auth_warning(self):
+        """Test _stream_message shows auth warning when needed."""
+        mock_task = _make_task(TaskState.auth_required)
+
+        async def mock_stream(*args, **kwargs):
+            yield StreamEvent(
+                event_type="status",
+                task=mock_task,
+            )
+
+        mock_service = MagicMock()
+        mock_service.stream = mock_stream
+
+        output = MagicMock(spec=Output)
+
+        with patch("a2a_handler.cli.message.update_session"):
+            await _stream_message(
+                mock_service,
+                "Hello",
+                None,
+                None,
+                "http://localhost:8000",
+                output,
+            )
+
+        output.warning.assert_called_with("Authentication required")

--- a/tests/test_cli_session.py
+++ b/tests/test_cli_session.py
@@ -1,0 +1,120 @@
+"""Tests for CLI session commands."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from a2a_handler.cli.session import session
+from a2a_handler.session import AgentSession, SessionStore
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+class TestSessionList:
+    """Tests for session list command."""
+
+    def test_list_no_sessions(self, runner):
+        """Test listing when no sessions exist."""
+        mock_store = MagicMock(spec=SessionStore)
+        mock_store.list_all.return_value = []
+
+        with patch(
+            "a2a_handler.cli.session.get_session_store", return_value=mock_store
+        ):
+            result = runner.invoke(session, ["list"])
+
+            assert result.exit_code == 0
+            assert "No saved sessions" in result.output
+
+    def test_list_with_sessions(self, runner):
+        """Test listing existing sessions."""
+        mock_store = MagicMock(spec=SessionStore)
+        mock_store.list_all.return_value = [
+            AgentSession(
+                agent_url="http://localhost:8000",
+                context_id="ctx-123",
+                task_id="task-456",
+            ),
+            AgentSession(
+                agent_url="http://localhost:9000",
+                context_id="ctx-789",
+            ),
+        ]
+
+        with patch(
+            "a2a_handler.cli.session.get_session_store", return_value=mock_store
+        ):
+            result = runner.invoke(session, ["list"])
+
+            assert result.exit_code == 0
+            assert "localhost:8000" in result.output
+            assert "localhost:9000" in result.output
+            assert "ctx-123" in result.output
+            assert "task-456" in result.output
+
+
+class TestSessionShow:
+    """Tests for session show command."""
+
+    def test_show_session_with_ids(self, runner):
+        """Test showing a session with context and task IDs."""
+        mock_session = AgentSession(
+            agent_url="http://localhost:8000",
+            context_id="ctx-123",
+            task_id="task-456",
+        )
+
+        with patch("a2a_handler.cli.session.get_session", return_value=mock_session):
+            result = runner.invoke(session, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "ctx-123" in result.output
+            assert "task-456" in result.output
+
+    def test_show_session_without_ids(self, runner):
+        """Test showing a session without saved IDs."""
+        mock_session = AgentSession(
+            agent_url="http://localhost:8000",
+            context_id=None,
+            task_id=None,
+        )
+
+        with patch("a2a_handler.cli.session.get_session", return_value=mock_session):
+            result = runner.invoke(session, ["show", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "none" in result.output.lower()
+
+
+class TestSessionClear:
+    """Tests for session clear command."""
+
+    def test_clear_specific_session(self, runner):
+        """Test clearing a specific session."""
+        with patch("a2a_handler.cli.session.clear_session") as mock_clear:
+            result = runner.invoke(session, ["clear", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "Cleared" in result.output
+            mock_clear.assert_called_once_with("http://localhost:8000")
+
+    def test_clear_all_sessions(self, runner):
+        """Test clearing all sessions with --all flag."""
+        with patch("a2a_handler.cli.session.clear_session") as mock_clear:
+            result = runner.invoke(session, ["clear", "--all"])
+
+            assert result.exit_code == 0
+            assert "Cleared all" in result.output
+            mock_clear.assert_called_once_with()
+
+    def test_clear_without_args_shows_warning(self, runner):
+        """Test clearing without args shows warning."""
+        result = runner.invoke(session, ["clear"])
+
+        assert result.exit_code == 0
+        assert "Provide" in result.output or "--all" in result.output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,279 @@
+"""Tests for the Output class and related utilities."""
+
+from io import StringIO
+
+import pytest
+
+from a2a_handler.common.output import (
+    Output,
+    _supports_color,
+    TERMINAL_STATES,
+    SUCCESS_STATES,
+    ERROR_STATES,
+    WARNING_STATES,
+)
+
+
+class TestSupportsColor:
+    """Tests for _supports_color function."""
+
+    def test_supports_color_with_tty(self):
+        """Test that _supports_color returns True for TTY."""
+
+        class MockTTYStream(StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        result = _supports_color(MockTTYStream())  # type: ignore[arg-type]
+        assert result is True
+
+    def test_supports_color_without_tty(self):
+        """Test that _supports_color returns False for non-TTY."""
+
+        class MockNonTTYStream(StringIO):
+            def isatty(self) -> bool:
+                return False
+
+        result = _supports_color(MockNonTTYStream())  # type: ignore[arg-type]
+        assert result is False
+
+    def test_supports_color_no_isatty_method(self):
+        """Test that _supports_color returns False when isatty is missing."""
+
+        class NoIsatty:
+            pass
+
+        result = _supports_color(NoIsatty())  # type: ignore[arg-type]
+        assert result is False
+
+
+class TestStateConstants:
+    """Tests for state constant sets."""
+
+    def test_terminal_states(self):
+        """Test terminal states include expected values."""
+        assert "completed" in TERMINAL_STATES
+        assert "failed" in TERMINAL_STATES
+        assert "canceled" in TERMINAL_STATES
+        assert "rejected" in TERMINAL_STATES
+
+    def test_success_states(self):
+        """Test success states."""
+        assert "completed" in SUCCESS_STATES
+
+    def test_error_states(self):
+        """Test error states."""
+        assert "failed" in ERROR_STATES
+        assert "rejected" in ERROR_STATES
+
+    def test_warning_states(self):
+        """Test warning states."""
+        assert "canceled" in WARNING_STATES
+
+
+class TestOutput:
+    """Tests for Output class."""
+
+    @pytest.fixture
+    def output(self):
+        """Create an Output instance for testing."""
+        output = Output()
+        output._use_color = False
+        return output
+
+    @pytest.fixture
+    def captured_output(self, output):
+        """Create output capture context."""
+        captured = []
+
+        def capture_print(text):
+            captured.append(text)
+
+        output._print = capture_print
+        return captured
+
+    def test_line_basic(self, output, captured_output):
+        """Test basic line output."""
+        output.line("Hello, world!")
+        assert captured_output == ["Hello, world!"]
+
+    def test_line_with_style(self, output, captured_output):
+        """Test line output with style (no color mode)."""
+        output.line("Styled text", style="green")
+        assert captured_output == ["Styled text"]
+
+    def test_field_basic(self, output, captured_output):
+        """Test basic field output."""
+        output.field("Name", "Value")
+        assert len(captured_output) == 1
+        assert "Name:" in captured_output[0]
+        assert "Value" in captured_output[0]
+
+    def test_field_with_none_value(self, output, captured_output):
+        """Test field with None value."""
+        output.field("Name", None)
+        assert "none" in captured_output[0]
+
+    def test_header(self, output, captured_output):
+        """Test header output."""
+        output.header("Section Title")
+        assert len(captured_output) == 1
+        assert "Section Title" in captured_output[0]
+
+    def test_subheader(self, output, captured_output):
+        """Test subheader output."""
+        output.subheader("Sub Section")
+        assert captured_output == ["Sub Section"]
+
+    def test_blank(self, output, captured_output):
+        """Test blank line output."""
+        output.blank()
+        assert captured_output == [""]
+
+    def test_state_completed(self, output, captured_output):
+        """Test state output for completed."""
+        output.state("Status", "completed")
+        assert len(captured_output) == 1
+        assert "Status:" in captured_output[0]
+        assert "completed" in captured_output[0]
+
+    def test_state_failed(self, output, captured_output):
+        """Test state output for failed."""
+        output.state("Status", "failed")
+        assert "failed" in captured_output[0]
+
+    def test_state_canceled(self, output, captured_output):
+        """Test state output for canceled."""
+        output.state("Status", "canceled")
+        assert "canceled" in captured_output[0]
+
+    def test_state_working(self, output, captured_output):
+        """Test state output for working."""
+        output.state("Status", "working")
+        assert "working" in captured_output[0]
+
+    def test_success(self, output, captured_output):
+        """Test success message."""
+        output.success("Operation successful!")
+        assert captured_output == ["Operation successful!"]
+
+    def test_error(self, output, captured_output):
+        """Test error message."""
+        output.error("Something went wrong!")
+        assert captured_output == ["Something went wrong!"]
+
+    def test_warning(self, output, captured_output):
+        """Test warning message."""
+        output.warning("Be careful!")
+        assert captured_output == ["Be careful!"]
+
+    def test_dim(self, output, captured_output):
+        """Test dim message."""
+        output.dim("Muted text")
+        assert captured_output == ["Muted text"]
+
+    def test_json(self, output, captured_output):
+        """Test JSON output."""
+        output.json({"key": "value"})
+        assert len(captured_output) == 1
+        assert '"key"' in captured_output[0]
+        assert '"value"' in captured_output[0]
+
+    def test_json_with_non_serializable(self, output, captured_output):
+        """Test JSON output with non-serializable type (uses default=str)."""
+        from datetime import datetime
+
+        now = datetime.now()
+        output.json({"time": now})
+        assert len(captured_output) == 1
+
+    def test_markdown(self, output, captured_output):
+        """Test markdown output."""
+        output.markdown("# Header\n\nParagraph text")
+        assert captured_output == ["# Header\n\nParagraph text"]
+
+    def test_list_item(self, output, captured_output):
+        """Test list item output."""
+        output.list_item("First item")
+        assert "•" in captured_output[0]
+        assert "First item" in captured_output[0]
+
+    def test_list_item_custom_bullet(self, output, captured_output):
+        """Test list item with custom bullet."""
+        output.list_item("Item", bullet="→")
+        assert "→" in captured_output[0]
+        assert "Item" in captured_output[0]
+
+
+class TestOutputWithColor:
+    """Tests for Output class with color enabled."""
+
+    @pytest.fixture
+    def color_output(self):
+        """Create an Output instance with color enabled."""
+        output = Output()
+        output._use_color = True
+        return output
+
+    @pytest.fixture
+    def captured_output(self, color_output):
+        """Create output capture context."""
+        captured = []
+
+        def capture_print(text):
+            captured.append(text)
+
+        color_output._print = capture_print
+        return captured
+
+    def test_line_with_style_applies_color(self, color_output, captured_output):
+        """Test that styled lines apply ANSI codes."""
+        from a2a_handler.common.output import GREEN, RESET
+
+        color_output.line("Green text", style="green")
+        assert len(captured_output) == 1
+        assert GREEN in captured_output[0]
+        assert RESET in captured_output[0]
+
+    def test_error_applies_red_bold(self, color_output, captured_output):
+        """Test that error applies red and bold."""
+        from a2a_handler.common.output import RED, BOLD, RESET
+
+        color_output.error("Error message")
+        assert len(captured_output) == 1
+        assert RED in captured_output[0]
+        assert BOLD in captured_output[0]
+        assert RESET in captured_output[0]
+
+    def test_header_applies_bold(self, color_output, captured_output):
+        """Test that header applies bold."""
+        from a2a_handler.common.output import BOLD, RESET
+
+        color_output.header("Title")
+        assert len(captured_output) == 1
+        assert BOLD in captured_output[0]
+        assert RESET in captured_output[0]
+
+    def test_field_with_dim_value(self, color_output, captured_output):
+        """Test field with dimmed value."""
+        from a2a_handler.common.output import DIM
+
+        color_output.field("Name", "Value", dim_value=True)
+        assert len(captured_output) == 1
+        assert DIM in captured_output[0]
+
+    def test_field_with_value_style(self, color_output, captured_output):
+        """Test field with specific value style."""
+        from a2a_handler.common.output import CYAN
+
+        color_output.field("Name", "Value", value_style="cyan")
+        assert len(captured_output) == 1
+        assert CYAN in captured_output[0]
+
+    def test_state_applies_appropriate_color(self, color_output, captured_output):
+        """Test state applies color based on state type."""
+        from a2a_handler.common.output import GREEN
+
+        color_output.state("Status", "completed")
+        assert len(captured_output) == 1
+        assert GREEN in captured_output[0]

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,509 @@
+"""Tests for task CLI commands."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from click.testing import CliRunner
+from a2a.types import Task, TaskState, TaskStatus, PushNotificationConfig
+
+from a2a_handler.cli.task import task
+from a2a_handler.service import TaskResult, StreamEvent
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+def _make_task(
+    state: TaskState = TaskState.completed,
+    task_id: str = "task-123",
+    context_id: str = "ctx-123",
+) -> Task:
+    """Helper to create a Task with the given state."""
+    return Task(
+        id=task_id,
+        context_id=context_id,
+        status=TaskStatus(state=state),
+    )
+
+
+class TestTaskGet:
+    """Tests for task get command."""
+
+    def test_task_get_success(self, runner):
+        """Test successful task get command."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = TaskResult(task=mock_task, text="Task output text")
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(task, ["get", "http://localhost:8000", "task-123"])
+
+            assert result.exit_code == 0
+            assert "task-123" in result.output
+
+    def test_task_get_with_history_length(self, runner):
+        """Test task get with history length option."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = TaskResult(task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task, ["get", "http://localhost:8000", "task-123", "-n", "5"]
+            )
+
+            assert result.exit_code == 0
+            mock_service.get_task.assert_called_once_with("task-123", 5)
+
+    def test_task_get_with_bearer_auth(self, runner):
+        """Test task get with bearer token override."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = TaskResult(task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "get",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--bearer",
+                    "my-token",
+                ],
+            )
+
+            assert result.exit_code == 0
+            # Verify the service was created with credentials
+            call_kwargs = mock_service_cls.call_args.kwargs
+            assert call_kwargs["credentials"] is not None
+
+    def test_task_get_with_api_key_auth(self, runner):
+        """Test task get with API key override."""
+        mock_task = _make_task(TaskState.completed)
+        mock_result = TaskResult(task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                ["get", "http://localhost:8000", "task-123", "--api-key", "my-key"],
+            )
+
+            assert result.exit_code == 0
+
+    def test_task_get_connection_error(self, runner):
+        """Test task get handles connection errors gracefully."""
+        import httpx
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_task.side_effect = httpx.ConnectError("Connection refused")
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(task, ["get", "http://localhost:8000", "task-123"])
+
+            assert result.exit_code == 1
+            assert "Connection refused" in result.output
+
+
+class TestTaskCancel:
+    """Tests for task cancel command."""
+
+    def test_task_cancel_success(self, runner):
+        """Test successful task cancel command."""
+        mock_task = _make_task(TaskState.canceled)
+        mock_result = TaskResult(task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.cancel_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task, ["cancel", "http://localhost:8000", "task-123"]
+            )
+
+            assert result.exit_code == 0
+            assert "canceled" in result.output.lower()
+
+    def test_task_cancel_with_bearer(self, runner):
+        """Test task cancel with bearer token."""
+        mock_task = _make_task(TaskState.canceled)
+        mock_result = TaskResult(task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.cancel_task.return_value = mock_result
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "cancel",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--bearer",
+                    "token",
+                ],
+            )
+
+            assert result.exit_code == 0
+
+
+class TestTaskResubscribe:
+    """Tests for task resubscribe command."""
+
+    def test_task_resubscribe_streams_events(self, runner):
+        """Test task resubscribe yields stream events."""
+        mock_task = _make_task(TaskState.working)
+
+        async def mock_resubscribe(*args, **kwargs):
+            yield StreamEvent(
+                event_type="status",
+                task=mock_task,
+            )
+            yield StreamEvent(
+                event_type="artifact",
+                text="Some output text",
+            )
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = MagicMock()
+            mock_service.resubscribe = mock_resubscribe
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task, ["resubscribe", "http://localhost:8000", "task-123"]
+            )
+
+            assert result.exit_code == 0
+
+    def test_task_resubscribe_with_api_key(self, runner):
+        """Test task resubscribe with API key."""
+        mock_task = _make_task(TaskState.completed)
+
+        async def mock_resubscribe(*args, **kwargs):
+            yield StreamEvent(event_type="status", task=mock_task)
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = MagicMock()
+            mock_service.resubscribe = mock_resubscribe
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "resubscribe",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--api-key",
+                    "my-key",
+                ],
+            )
+
+            assert result.exit_code == 0
+
+
+class TestTaskNotificationSet:
+    """Tests for task notification set command."""
+
+    def test_notification_set_success(self, runner):
+        """Test successful notification set command."""
+        from a2a.types import TaskPushNotificationConfig
+
+        mock_config = TaskPushNotificationConfig(
+            task_id="task-123",
+            push_notification_config=PushNotificationConfig(
+                url="http://webhook.example.com",
+                token="secret-token",
+            ),
+        )
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.set_push_config.return_value = mock_config
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "set",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--url",
+                    "http://webhook.example.com",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "Push notification config set" in result.output
+
+    def test_notification_set_with_token(self, runner):
+        """Test notification set with authentication token."""
+        from a2a.types import TaskPushNotificationConfig
+
+        mock_config = TaskPushNotificationConfig(
+            task_id="task-123",
+            push_notification_config=PushNotificationConfig(
+                url="http://webhook.example.com",
+                token="webhook-token",
+            ),
+        )
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.set_push_config.return_value = mock_config
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "set",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--url",
+                    "http://webhook.example.com",
+                    "--token",
+                    "webhook-token",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_service.set_push_config.assert_called_once_with(
+                "task-123", "http://webhook.example.com", "webhook-token"
+            )
+
+    def test_notification_set_requires_url(self, runner):
+        """Test that notification set requires --url."""
+        result = runner.invoke(
+            task,
+            [
+                "notification",
+                "set",
+                "http://localhost:8000",
+                "task-123",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+class TestTaskNotificationGet:
+    """Tests for task notification get command."""
+
+    def test_notification_get_success(self, runner):
+        """Test successful notification get command."""
+        from a2a.types import TaskPushNotificationConfig
+
+        mock_config = TaskPushNotificationConfig(
+            task_id="task-123",
+            push_notification_config=PushNotificationConfig(
+                url="http://webhook.example.com",
+                token="secret-token",
+                id="config-id-123",
+            ),
+        )
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_push_config.return_value = mock_config
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task, ["notification", "get", "http://localhost:8000", "task-123"]
+            )
+
+            assert result.exit_code == 0
+            assert "task-123" in result.output
+            assert "http://webhook.example.com" in result.output
+
+    def test_notification_get_with_config_id(self, runner):
+        """Test notification get with specific config ID."""
+        from a2a.types import TaskPushNotificationConfig
+
+        mock_config = TaskPushNotificationConfig(
+            task_id="task-123",
+            push_notification_config=PushNotificationConfig(
+                url="http://webhook.example.com",
+                id="specific-config-id",
+            ),
+        )
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_push_config.return_value = mock_config
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "get",
+                    "http://localhost:8000",
+                    "task-123",
+                    "--config-id",
+                    "specific-config-id",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_service.get_push_config.assert_called_once_with(
+                "task-123", "specific-config-id"
+            )
+
+
+class TestFormatTaskResult:
+    """Tests for _format_task_result helper."""
+
+    def test_format_task_result_completed(self):
+        """Test formatting a completed task result."""
+        from a2a_handler.cli.task import _format_task_result
+        from a2a_handler.common import Output
+        from unittest.mock import MagicMock
+
+        mock_task = _make_task(TaskState.completed, context_id="ctx-abc")
+        result = TaskResult(task=mock_task, text="Output text here")
+
+        output = MagicMock(spec=Output)
+        _format_task_result(result, output)
+
+        output.field.assert_any_call("Task ID", "task-123", dim_value=True)
+        output.state.assert_called_with("State", "completed")
+        output.markdown.assert_called_with("Output text here")
+
+    def test_format_task_result_no_text(self):
+        """Test formatting a task result without text."""
+        from a2a_handler.cli.task import _format_task_result
+        from a2a_handler.common import Output
+        from unittest.mock import MagicMock
+
+        mock_task = _make_task(TaskState.working)
+        result = TaskResult(task=mock_task, text="")
+
+        output = MagicMock(spec=Output)
+        _format_task_result(result, output)
+
+        output.markdown.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.5" },
+    { name = "a2a-sdk", specifier = ">=0.3.22" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "google-adk", specifier = ">=0.5.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -59,7 +59,7 @@ dev = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.16"
+version = "0.3.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -68,9 +68,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/57/0c5605a956646c3a3fe0a6f0eb2eb1193718b01b5ef3fb7288b20684e67b/a2a_sdk-0.3.16.tar.gz", hash = "sha256:bc579091cfcf18341076379ea7efb361df0aca4822db05db7267d9d7f881e964", size = 228805, upload-time = "2025-11-21T13:34:48.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/a3/76f2d94a32a1b0dc760432d893a09ec5ed31de5ad51b1ef0f9d199ceb260/a2a_sdk-0.3.22.tar.gz", hash = "sha256:77a5694bfc4f26679c11b70c7f1062522206d430b34bc1215cfbb1eba67b7e7d", size = 231535, upload-time = "2025-12-16T18:39:21.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/e9/2fb9871bb416ae34b3a8f3c08de4bccb0a9b3b1dc0cb9a48940b13c14601/a2a_sdk-0.3.16-py3-none-any.whl", hash = "sha256:e5e1d6f8208985ed42b488dde9721bfb9efdf94e903700bb6c53d599b1433e03", size = 141390, upload-time = "2025-11-21T13:34:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e8/f4e39fd1cf0b3c4537b974637143f3ebfe1158dad7232d9eef15666a81ba/a2a_sdk-0.3.22-py3-none-any.whl", hash = "sha256:b98701135bb90b0ff85d35f31533b6b7a299bf810658c1c65f3814a6c15ea385", size = 144347, upload-time = "2025-12-16T18:39:19.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the CLI and TUI for task management, as well as some dependency and configuration updates. The most significant changes are the addition of bearer/API key authentication options for task-related CLI commands, the implementation of a new CLI command to retrieve task push notification configurations, and the introduction of a new "Tasks" panel in the TUI with improved keyboard navigation and clipboard support.

**Authentication and CLI Improvements:**

* Added `--bearer` and `--api-key` options to all task-related CLI commands (`task_get`, `task_cancel`, `task_resubscribe`, `notification_set`) to allow overriding saved credentials with a bearer token or API key; updated the logic to use these credentials when provided. [[1]](diffhunk://#diff-39a824883c7e5add3f765f876ffcafacc59d27b19b3afb9667dc348340499ce9R30-R54) [[2]](diffhunk://#diff-39a824883c7e5add3f765f876ffcafacc59d27b19b3afb9667dc348340499ce9L53-R90) [[3]](diffhunk://#diff-39a824883c7e5add3f765f876ffcafacc59d27b19b3afb9667dc348340499ce9L80-R132) [[4]](diffhunk://#diff-39a824883c7e5add3f765f876ffcafacc59d27b19b3afb9667dc348340499ce9R176-R201)
* Added a new `notification_get` CLI command to retrieve the push notification configuration for a task, with support for credential overrides and optional config ID. [[1]](diffhunk://#diff-39a824883c7e5add3f765f876ffcafacc59d27b19b3afb9667dc348340499ce9R222-R269) [[2]](diffhunk://#diff-6d1fbacb0fd8435c83aff0521a798fec28f08c56e164e219e0891168cc94fe6cR14) [[3]](diffhunk://#diff-6d1fbacb0fd8435c83aff0521a798fec28f08c56e164e219e0891168cc94fe6cR570-R593)

**TUI Enhancements:**

* Introduced a new `TasksPanel` in the TUI, accessible via a "Tasks" tab, with support for displaying, updating, and navigating tasks, as well as copying task/context IDs to the clipboard. [[1]](diffhunk://#diff-e4e3d3f67e9a3dce240b9a2ad348748f51d97b3d37449fa04370f3fdd8c5ad4fR9) [[2]](diffhunk://#diff-e4e3d3f67e9a3dce240b9a2ad348748f51d97b3d37449fa04370f3fdd8c5ad4fR20) [[3]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R17-R21) [[4]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R141-R165) [[5]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R190-R192) [[6]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R245-R254) [[7]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R264) [[8]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R273) [[9]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R283-R293) [[10]](diffhunk://#diff-0a612bff8b8341b1c13112744774f228a95f3fd9a202c139f4876736c75216a7R322-R335) [[11]](diffhunk://#diff-f13ba399b401d37c017fab5dedda88ae173e18ff612ac0d246f4eb6252d5eaa0R220-R330)
* Updated the TUI to automatically update the tasks panel when a new task is received as part of a message send result.

**Configuration and Dependency Updates:**

* Updated the `a2a-sdk` dependency version from `>=0.2.5` to `>=0.3.22` in `pyproject.toml`.
* Changed rich-click configuration to use markdown as the text markup format.