### PR TITLE
Web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "rich>=13.0.0",
     "textual>=0.47.0",
     "uvicorn>=0.30.0",
+    "textual-serve>=1.1.0",
 ]
 
 [dependency-groups]

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -69,6 +69,23 @@ def tui() -> None:
     app.run()
 
 
+@cli.command()
+@click.option("--host", default="localhost", help="Host to bind to", show_default=True)
+@click.option("--port", "-p", default=8001, help="Port to bind to", show_default=True)
+def web(host: str, port: int) -> None:
+    """Serve the TUI as a web application."""
+    from textual_serve.server import Server
+
+    log.info("Starting web server on %s:%d", host, port)
+    server = Server(
+        command="handler tui",
+        host=host,
+        port=port,
+        title="Handler",
+    )
+    server.serve()
+
+
 def main() -> None:
     """Main entry point for the CLI."""
     cli()

--- a/src/a2a_handler/cli/_config.py
+++ b/src/a2a_handler/cli/_config.py
@@ -74,7 +74,7 @@ click.rich_click.COMMAND_GROUPS = {
         {"name": "Agent Communication", "commands": ["message", "task"]},
         {"name": "Agent Discovery", "commands": ["card"]},
         {"name": "Authentication", "commands": ["auth"]},
-        {"name": "Interfaces", "commands": ["tui", "server"]},
+        {"name": "Interfaces", "commands": ["tui", "web", "server"]},
         {"name": "Utilities", "commands": ["session", "version"]},
     ],
     "handler message": [

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
     { name = "rich" },
     { name = "rich-click" },
     { name = "textual" },
+    { name = "textual-serve" },
     { name = "uvicorn" },
 ]
 
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-click", specifier = ">=1.8.0" },
     { name = "textual", specifier = ">=0.47.0" },
+    { name = "textual-serve", specifier = ">=1.1.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 


### PR DESCRIPTION
This pull request adds support for serving the TUI (Textual User Interface) as a web application, in addition to the existing terminal interface. The most important changes include introducing a new CLI command for launching the TUI via a web server, updating dependencies, and reflecting the new command in the help/configuration.

**New Web Serving Feature:**

* Added a new CLI command `web` to serve the TUI as a web application, with configurable host and port options using `textual-serve`. (`src/a2a_handler/cli/__init__.py`)
* Included the new `web` command under the "Interfaces" section in the CLI configuration for discoverability. (`src/a2a_handler/cli/_config.py`)

**Dependency Updates:**

* Added `textual-serve>=1.1.0` to project dependencies to support web serving of the TUI. (`pyproject.toml`)