### PR TITLE
Add MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "textual>=0.47.0",
     "uvicorn>=0.30.0",
     "textual-serve>=1.1.0",
+    "mcp[cli]>=1.2.0",
 ]
 
 [dependency-groups]

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -22,6 +22,7 @@ from a2a_handler.tui import HandlerTUI
 from . import _config  # noqa: F401 - configures rich-click on import
 from .auth import auth
 from .card import card
+from .mcp import mcp
 from .message import message
 from .server import server
 from .session import session
@@ -52,6 +53,7 @@ cli.add_command(card)
 cli.add_command(server)
 cli.add_command(session)
 cli.add_command(auth)
+cli.add_command(mcp)
 
 
 @cli.command()

--- a/src/a2a_handler/cli/mcp.py
+++ b/src/a2a_handler/cli/mcp.py
@@ -1,0 +1,48 @@
+"""MCP server CLI command."""
+
+from typing import Literal
+
+import rich_click as click
+
+from a2a_handler.common import get_logger
+
+log = get_logger(__name__)
+
+TransportType = Literal["stdio", "sse", "streamable-http"]
+
+
+@click.command()
+@click.option(
+    "--transport",
+    "-t",
+    type=click.Choice(["stdio", "sse", "streamable-http"]),
+    default="stdio",
+    help="Transport protocol to use",
+    show_default=True,
+)
+def mcp(transport: TransportType) -> None:
+    """Run a local MCP server exposing A2A capabilities.
+
+    This starts an MCP (Model Context Protocol) server that exposes Handler's
+    A2A functionality as MCP tools and resources. You can connect to this
+    server from any MCP-compatible client (like Claude Desktop, Cursor, etc.).
+
+    The server provides tools for:
+    - Validating A2A agent cards
+    - More capabilities coming soon...
+
+    Example configuration for Claude Desktop (claude_desktop_config.json):
+
+        {
+          "mcpServers": {
+            "handler": {
+              "command": "handler",
+              "args": ["mcp"]
+            }
+          }
+        }
+    """
+    from a2a_handler.mcp import run_mcp_server
+
+    log.info("Starting MCP server with %s transport", transport)
+    run_mcp_server(transport=transport)

--- a/src/a2a_handler/cli/mcp.py
+++ b/src/a2a_handler/cli/mcp.py
@@ -28,8 +28,33 @@ def mcp(transport: TransportType) -> None:
     server from any MCP-compatible client (like Claude Desktop, Cursor, etc.).
 
     The server provides tools for:
-    - Validating A2A agent cards
-    - More capabilities coming soon...
+
+    \b
+    Card Tools:
+    - validate_agent_card: Validate an agent card from URL or file
+    - get_agent_card: Retrieve an agent's full card details
+
+    \b
+    Message Tools:
+    - send_message: Send messages to agents with session/auth support
+
+    \b
+    Task Tools:
+    - get_task: Get task status and details
+    - cancel_task: Cancel a running task
+    - set_task_notification: Configure push notification webhooks
+    - get_task_notification: Get push notification config
+
+    \b
+    Session Tools:
+    - list_sessions: List all saved sessions
+    - get_session_info: Get session for a specific agent
+    - clear_session_data: Clear saved session state
+
+    \b
+    Auth Tools:
+    - set_agent_credentials: Save bearer token or API key
+    - clear_agent_credentials: Remove saved credentials
 
     Example configuration for Claude Desktop (claude_desktop_config.json):
 

--- a/src/a2a_handler/mcp/__init__.py
+++ b/src/a2a_handler/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server exposing Handler's A2A capabilities as MCP tools and resources."""
+
+from a2a_handler.mcp.server import create_mcp_server, run_mcp_server
+
+__all__ = ["create_mcp_server", "run_mcp_server"]

--- a/src/a2a_handler/mcp/server.py
+++ b/src/a2a_handler/mcp/server.py
@@ -10,6 +10,8 @@ from a2a_handler.common import get_logger
 from a2a_handler.service import A2AService
 from a2a_handler.session import (
     clear_credentials as session_clear_credentials,
+)
+from a2a_handler.session import (
     clear_session,
     get_credentials,
     get_session,
@@ -49,17 +51,14 @@ def _resolve_credentials(
 def create_mcp_server() -> FastMCP:
     """Create and configure the MCP server with A2A tools."""
     mcp = FastMCP(
-        "Handler",
+        name="Handler",
         instructions=(
             "Handler exposes A2A (Agent-to-Agent) protocol capabilities. "
             "Use these tools to interact with A2A agents, validate agent cards, "
             "and discover agent capabilities."
         ),
+        website_url="https://github.com/alDuncanson/handler",
     )
-
-    # =========================================================================
-    # Card Tools
-    # =========================================================================
 
     @mcp.tool()
     async def validate_agent_card(
@@ -150,10 +149,6 @@ def create_mcp_server() -> FastMCP:
 
             return card.model_dump(exclude_none=True)
 
-    # =========================================================================
-    # Message Tools
-    # =========================================================================
-
     @mcp.tool()
     async def send_message(
         agent_url: str,
@@ -216,10 +211,6 @@ def create_mcp_server() -> FastMCP:
                 "needs_input": result.needs_input,
                 "needs_auth": result.needs_auth,
             }
-
-    # =========================================================================
-    # Task Tools
-    # =========================================================================
 
     @mcp.tool()
     async def get_task(
@@ -395,10 +386,6 @@ def create_mcp_server() -> FastMCP:
 
             return result
 
-    # =========================================================================
-    # Session Tools
-    # =========================================================================
-
     @mcp.tool()
     async def list_sessions() -> dict:
         """List all saved sessions.
@@ -481,10 +468,6 @@ def create_mcp_server() -> FastMCP:
             logger.info("Clearing all sessions")
             clear_session()
             return {"cleared": "All sessions"}
-
-    # =========================================================================
-    # Auth Tools
-    # =========================================================================
 
     @mcp.tool()
     async def set_agent_credentials(

--- a/src/a2a_handler/mcp/server.py
+++ b/src/a2a_handler/mcp/server.py
@@ -1,0 +1,562 @@
+"""MCP server implementation exposing A2A capabilities as tools and resources."""
+
+from typing import Literal
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+from a2a_handler.auth import AuthCredentials, create_api_key_auth, create_bearer_auth
+from a2a_handler.common import get_logger
+from a2a_handler.service import A2AService
+from a2a_handler.session import (
+    clear_credentials as session_clear_credentials,
+    clear_session,
+    get_credentials,
+    get_session,
+    get_session_store,
+    set_credentials,
+    update_session,
+)
+from a2a_handler.validation import (
+    ValidationResult,
+    validate_agent_card_from_file,
+    validate_agent_card_from_url,
+)
+
+logger = get_logger(__name__)
+
+TIMEOUT = 120
+
+
+def _build_http_client(timeout: int = TIMEOUT) -> httpx.AsyncClient:
+    """Build an HTTP client with the specified timeout."""
+    return httpx.AsyncClient(timeout=timeout)
+
+
+def _resolve_credentials(
+    agent_url: str,
+    bearer_token: str | None = None,
+    api_key: str | None = None,
+) -> AuthCredentials | None:
+    """Resolve credentials from explicit args or saved session."""
+    if bearer_token:
+        return create_bearer_auth(bearer_token)
+    if api_key:
+        return create_api_key_auth(api_key)
+    return get_credentials(agent_url)
+
+
+def create_mcp_server() -> FastMCP:
+    """Create and configure the MCP server with A2A tools."""
+    mcp = FastMCP(
+        "Handler",
+        instructions=(
+            "Handler exposes A2A (Agent-to-Agent) protocol capabilities. "
+            "Use these tools to interact with A2A agents, validate agent cards, "
+            "and discover agent capabilities."
+        ),
+    )
+
+    # =========================================================================
+    # Card Tools
+    # =========================================================================
+
+    @mcp.tool()
+    async def validate_agent_card(
+        source: str,
+        from_file: bool = False,
+    ) -> dict:
+        """Validate an A2A agent card from a URL or local file.
+
+        Use this tool to check if an agent card is valid according to the A2A protocol.
+        The agent card contains metadata about an agent's capabilities, supported
+        content types, and authentication requirements.
+
+        Args:
+            source: URL of the agent (e.g., "http://localhost:8000") or path to a
+                   local JSON file containing the agent card.
+            from_file: If True, treat source as a file path. If False (default),
+                      treat source as an agent URL.
+
+        Returns:
+            A dictionary containing:
+            - valid: Whether the agent card is valid
+            - agent_name: Name of the agent (if available)
+            - protocol_version: A2A protocol version
+            - issues: List of validation issues (if any)
+        """
+        logger.info("Validating agent card from %s", source)
+
+        result: ValidationResult
+        if from_file:
+            result = validate_agent_card_from_file(source)
+        else:
+            result = await validate_agent_card_from_url(source)
+
+        response: dict = {
+            "valid": result.valid,
+            "source": result.source,
+            "source_type": result.source_type.value,
+            "agent_name": result.agent_name,
+            "protocol_version": result.protocol_version,
+        }
+
+        if result.issues:
+            response["issues"] = [
+                {
+                    "field": issue.field_name,
+                    "message": issue.message,
+                    "type": issue.issue_type,
+                }
+                for issue in result.issues
+            ]
+
+        if result.agent_card:
+            response["capabilities"] = {
+                "streaming": result.agent_card.capabilities.streaming
+                if result.agent_card.capabilities
+                else False,
+                "push_notifications": result.agent_card.capabilities.push_notifications
+                if result.agent_card.capabilities
+                else False,
+            }
+            if result.agent_card.skills:
+                response["skills"] = [
+                    {"id": skill.id, "name": skill.name}
+                    for skill in result.agent_card.skills
+                ]
+
+        return response
+
+    @mcp.tool()
+    async def get_agent_card(agent_url: str) -> dict:
+        """Retrieve an agent's card with full details.
+
+        Fetches the agent card from the specified A2A agent URL. The agent card
+        contains metadata about the agent including its name, description,
+        capabilities, skills, and supported content types.
+
+        Args:
+            agent_url: Base URL of the A2A agent (e.g., "http://localhost:8000")
+
+        Returns:
+            The agent card as a dictionary with all available fields.
+        """
+        logger.info("Getting agent card from %s", agent_url)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(http_client, agent_url)
+            card = await service.get_card()
+
+            return card.model_dump(exclude_none=True)
+
+    # =========================================================================
+    # Message Tools
+    # =========================================================================
+
+    @mcp.tool()
+    async def send_message(
+        agent_url: str,
+        message: str,
+        context_id: str | None = None,
+        task_id: str | None = None,
+        use_session: bool = False,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Send a message to an A2A agent and receive a response.
+
+        This is the primary way to interact with A2A agents. Send a text message
+        and receive the agent's response. Use context_id and task_id for
+        conversation continuity.
+
+        Args:
+            agent_url: Base URL of the A2A agent (e.g., "http://localhost:8000")
+            message: The text message to send to the agent
+            context_id: Optional context ID for conversation continuity
+            task_id: Optional task ID to continue an existing task
+            use_session: If True, use saved session context (context_id/task_id)
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - context_id: Context ID for follow-up messages
+            - task_id: Task ID for task operations
+            - state: Current task state (e.g., "completed", "working", "input-required")
+            - text: The agent's response text
+            - needs_input: Whether the agent needs more input
+            - needs_auth: Whether authentication is required
+        """
+        logger.info("Sending message to %s", agent_url)
+
+        if use_session and not context_id:
+            session = get_session(agent_url)
+            if session.context_id:
+                context_id = session.context_id
+                logger.info("Using saved context: %s", context_id)
+
+        credentials = _resolve_credentials(agent_url, bearer_token, api_key)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(
+                http_client,
+                agent_url,
+                credentials=credentials,
+            )
+
+            result = await service.send(message, context_id, task_id)
+            update_session(agent_url, result.context_id, result.task_id)
+
+            return {
+                "context_id": result.context_id,
+                "task_id": result.task_id,
+                "state": result.state.value if result.state else None,
+                "text": result.text,
+                "needs_input": result.needs_input,
+                "needs_auth": result.needs_auth,
+            }
+
+    # =========================================================================
+    # Task Tools
+    # =========================================================================
+
+    @mcp.tool()
+    async def get_task(
+        agent_url: str,
+        task_id: str,
+        history_length: int | None = None,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Get the current status and details of a task.
+
+        Retrieves the current state of a task from an A2A agent, optionally
+        including conversation history.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task to retrieve
+            history_length: Optional number of history messages to include
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - task_id: The task ID
+            - context_id: The context ID
+            - state: Current task state
+            - text: Response text from artifacts or history
+        """
+        logger.info("Getting task %s from %s", task_id, agent_url)
+
+        credentials = _resolve_credentials(agent_url, bearer_token, api_key)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            result = await service.get_task(task_id, history_length)
+
+            return {
+                "task_id": result.task_id,
+                "context_id": result.context_id,
+                "state": result.state.value,
+                "text": result.text,
+            }
+
+    @mcp.tool()
+    async def cancel_task(
+        agent_url: str,
+        task_id: str,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Cancel a running task.
+
+        Requests cancellation of a task that is currently in progress.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task to cancel
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - task_id: The task ID
+            - context_id: The context ID
+            - state: Updated task state (should be "canceled")
+            - text: Any final response text
+        """
+        logger.info("Canceling task %s at %s", task_id, agent_url)
+
+        credentials = _resolve_credentials(agent_url, bearer_token, api_key)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            result = await service.cancel_task(task_id)
+
+            return {
+                "task_id": result.task_id,
+                "context_id": result.context_id,
+                "state": result.state.value,
+                "text": result.text,
+            }
+
+    @mcp.tool()
+    async def set_task_notification(
+        agent_url: str,
+        task_id: str,
+        webhook_url: str,
+        webhook_token: str | None = None,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Configure push notifications for a task.
+
+        Sets up a webhook URL to receive push notifications when the task
+        status changes. This allows for async notification instead of polling.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task to configure notifications for
+            webhook_url: URL that will receive notification POSTs
+            webhook_token: Optional authentication token for the webhook
+            bearer_token: Optional bearer token for agent authentication
+            api_key: Optional API key for agent authentication
+
+        Returns:
+            A dictionary containing:
+            - task_id: The task ID
+            - url: The configured webhook URL
+            - token: The webhook token (truncated for security)
+            - config_id: The notification config ID (if provided by agent)
+        """
+        logger.info("Setting push config for task %s at %s", task_id, agent_url)
+
+        credentials = _resolve_credentials(agent_url, bearer_token, api_key)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            config = await service.set_push_config(task_id, webhook_url, webhook_token)
+
+            result: dict = {"task_id": config.task_id}
+            if config.push_notification_config:
+                pnc = config.push_notification_config
+                result["url"] = pnc.url
+                if pnc.token:
+                    result["token"] = f"{pnc.token[:20]}..."
+                if pnc.id:
+                    result["config_id"] = pnc.id
+
+            return result
+
+    @mcp.tool()
+    async def get_task_notification(
+        agent_url: str,
+        task_id: str,
+        config_id: str | None = None,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Get the push notification configuration for a task.
+
+        Retrieves the current push notification webhook configuration for a task.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task
+            config_id: Optional specific config ID to retrieve
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - task_id: The task ID
+            - url: The configured webhook URL
+            - token: The webhook token (truncated for security)
+            - config_id: The notification config ID
+        """
+        logger.info("Getting push config for task %s at %s", task_id, agent_url)
+
+        credentials = _resolve_credentials(agent_url, bearer_token, api_key)
+
+        async with _build_http_client() as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            config = await service.get_push_config(task_id, config_id)
+
+            result: dict = {"task_id": config.task_id}
+            if config.push_notification_config:
+                pnc = config.push_notification_config
+                result["url"] = pnc.url
+                if pnc.token:
+                    result["token"] = f"{pnc.token[:20]}..."
+                if pnc.id:
+                    result["config_id"] = pnc.id
+
+            return result
+
+    # =========================================================================
+    # Session Tools
+    # =========================================================================
+
+    @mcp.tool()
+    async def list_sessions() -> dict:
+        """List all saved sessions.
+
+        Sessions store context_id, task_id, and credentials for agents you've
+        interacted with. This allows for conversation continuity across
+        multiple interactions.
+
+        Returns:
+            A dictionary containing:
+            - count: Number of saved sessions
+            - sessions: List of sessions with agent_url, context_id, task_id,
+                       and has_credentials flag
+        """
+        logger.info("Listing all sessions")
+
+        store = get_session_store()
+        sessions = store.list_all()
+
+        return {
+            "count": len(sessions),
+            "sessions": [
+                {
+                    "agent_url": s.agent_url,
+                    "context_id": s.context_id,
+                    "task_id": s.task_id,
+                    "has_credentials": s.credentials is not None,
+                }
+                for s in sessions
+            ],
+        }
+
+    @mcp.tool()
+    async def get_session_info(agent_url: str) -> dict:
+        """Get session information for a specific agent.
+
+        Retrieves the saved session state for an agent, including context_id
+        and task_id for conversation continuity.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+
+        Returns:
+            A dictionary containing:
+            - agent_url: The agent URL
+            - context_id: Saved context ID (or None)
+            - task_id: Saved task ID (or None)
+            - has_credentials: Whether credentials are saved
+        """
+        logger.info("Getting session for %s", agent_url)
+
+        session = get_session(agent_url)
+
+        return {
+            "agent_url": session.agent_url,
+            "context_id": session.context_id,
+            "task_id": session.task_id,
+            "has_credentials": session.credentials is not None,
+        }
+
+    @mcp.tool()
+    async def clear_session_data(agent_url: str | None = None) -> dict:
+        """Clear saved session data.
+
+        Removes saved session state (context_id, task_id) for an agent or all
+        agents. Does not clear credentials - use clear_agent_credentials for that.
+
+        Args:
+            agent_url: URL of agent to clear. If None, clears ALL sessions.
+
+        Returns:
+            A dictionary containing:
+            - cleared: Description of what was cleared
+        """
+        if agent_url:
+            logger.info("Clearing session for %s", agent_url)
+            clear_session(agent_url)
+            return {"cleared": f"Session for {agent_url}"}
+        else:
+            logger.info("Clearing all sessions")
+            clear_session()
+            return {"cleared": "All sessions"}
+
+    # =========================================================================
+    # Auth Tools
+    # =========================================================================
+
+    @mcp.tool()
+    async def set_agent_credentials(
+        agent_url: str,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+    ) -> dict:
+        """Set authentication credentials for an agent.
+
+        Saves credentials that will be used for all future requests to this
+        agent. Either bearer_token or api_key should be provided, not both.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            bearer_token: Bearer token for Authorization header
+            api_key: API key for X-API-Key header
+
+        Returns:
+            A dictionary containing:
+            - agent_url: The agent URL
+            - auth_type: Type of auth configured ("bearer" or "api_key")
+        """
+        logger.info("Setting credentials for %s", agent_url)
+
+        if bearer_token:
+            credentials = create_bearer_auth(bearer_token)
+            set_credentials(agent_url, credentials)
+            return {"agent_url": agent_url, "auth_type": "bearer"}
+        elif api_key:
+            credentials = create_api_key_auth(api_key)
+            set_credentials(agent_url, credentials)
+            return {"agent_url": agent_url, "auth_type": "api_key"}
+        else:
+            return {"error": "Either bearer_token or api_key must be provided"}
+
+    @mcp.tool()
+    async def clear_agent_credentials(agent_url: str) -> dict:
+        """Clear saved credentials for an agent.
+
+        Removes any saved authentication credentials for the specified agent.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+
+        Returns:
+            A dictionary containing:
+            - agent_url: The agent URL
+            - cleared: True if credentials were cleared
+        """
+        logger.info("Clearing credentials for %s", agent_url)
+
+        session_clear_credentials(agent_url)
+
+        return {"agent_url": agent_url, "cleared": True}
+
+    return mcp
+
+
+def run_mcp_server(
+    transport: Literal["stdio", "sse", "streamable-http"] = "stdio",
+) -> None:
+    """Run the MCP server with the specified transport.
+
+    Args:
+        transport: The transport protocol to use. Supported values:
+                  - "stdio": Standard input/output (default, for CLI integration)
+                  - "sse": Server-Sent Events (for HTTP clients)
+    """
+    mcp = create_mcp_server()
+    logger.info("Starting MCP server with %s transport", transport)
+    mcp.run(transport=transport)
+
+
+if __name__ == "__main__":
+    run_mcp_server()

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "google-adk" },
     { name = "httpx" },
     { name = "litellm" },
+    { name = "mcp", extra = ["cli"] },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "rich-click" },
@@ -42,6 +43,7 @@ requires-dist = [
     { name = "google-adk", specifier = ">=0.5.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.0.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rich-click", specifier = ">=1.8.0" },
@@ -1770,6 +1772,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/af/01fb42df59ad15925ffc1e2e609adafddd3ac4572f606faae0dc8b55ba0c/mcp-1.21.1-py3-none-any.whl", hash = "sha256:dd35abe36d68530a8a1291daa25d50276d8731e545c0434d6e250a3700dd2a6d", size = 174852, upload-time = "2025-11-13T20:33:44.502Z" },
 ]
 
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
 [[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
@@ -3283,6 +3291,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/a7/4636369731b24ed07c2b4c7805b8d990283d677180662c532d82e4ef1a36/ty-0.0.1a27-py3-none-win32.whl", hash = "sha256:61782e5f40e6df622093847b34c366634b75d53f839986f1bf4481672ad6cb55", size = 8783816, upload-time = "2025-11-18T21:55:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/a7/1d/b76487725628d9e81d9047dc0033a5e167e0d10f27893d04de67fe1a9763/ty-0.0.1a27-py3-none-win_amd64.whl", hash = "sha256:c682b238085d3191acddcf66ef22641562946b1bba2a7f316012d5b2a2f4de11", size = 9616833, upload-time = "2025-11-18T21:55:12.457Z" },
     { url = "https://files.pythonhosted.org/packages/3a/db/c7cd5276c8f336a3cf87992b75ba9d486a7cf54e753fcd42495b3bc56fb7/ty-0.0.1a27-py3-none-win_arm64.whl", hash = "sha256:e146dfa32cbb0ac6afb0cb65659e87e4e313715e68d76fe5ae0a4b3d5b912ce8", size = 9137796, upload-time = "2025-11-18T21:55:15.897Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c1/933d30fd7a123ed981e2a1eedafceab63cb379db0402e438a13bc51bbb15/typer-0.20.1.tar.gz", hash = "sha256:68585eb1b01203689c4199bc440d6be616f0851e9f0eb41e4a778845c5a0fd5b", size = 105968, upload-time = "2025-12-19T16:48:56.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl", hash = "sha256:4b3bde918a67c8e03d861aa02deca90a95bbac572e71b1b9be56ff49affdb5a8", size = 47381, upload-time = "2025-12-19T16:48:53.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a new CLI command to run a local MCP (Model Context Protocol) server, exposing Handler’s A2A capabilities as MCP tools and resources. The main changes include adding the required dependency, implementing the `mcp` CLI command, and wiring it into the CLI entrypoint. This enables integration with MCP-compatible clients (such as Claude Desktop and Cursor) and provides a range of tools for cards, messages, tasks, sessions, and authentication.

**New MCP Server CLI Integration:**

- Added `mcp[cli]>=1.2.0` as a dependency in `pyproject.toml` to support MCP server functionality.
- Implemented a new `mcp` CLI command in `src/a2a_handler/cli/mcp.py` that starts the MCP server with configurable transport protocols and exposes detailed help/documentation for users.
- Registered the new `mcp` command with the main CLI by importing and adding it in `src/a2a_handler/cli/__init__.py`. [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R25) [[2]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R56)

**MCP Server Module:**

- Created `src/a2a_handler/mcp/__init__.py` to expose the MCP server’s main entrypoints (`create_mcp_server`, `run_mcp_server`) for use by the CLI.