### PR TITLE
Docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build docs
+        run: bun run build.ts
+        working-directory: docs
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           bun-version: latest
 
       - name: Build docs
-        run: bun run build.ts
+        run: bun build src/index.html --outdir dist --minify
         working-directory: docs
 
       - uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,4 @@ src/a2a_handler/
 - **Linting**: `ruff check`
 - **Type Checking**: `ty check`
 - **Testing**: pytest with pytest-asyncio
+- **No emojis**: Use Unicode symbols (e.g., `\u2600` for sun, `\u2713` for checkmark) instead of emojis in code, docs, comments, and UI

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![A2A Protocol](https://img.shields.io/badge/A2A_Protocol-v0.3.0-blue)](https://a2a-protocol.org/latest/)
 [![PyPI version](https://img.shields.io/pypi/v/a2a-handler)](https://pypi.org/project/a2a-handler/)
 [![PyPI - Status](https://img.shields.io/pypi/status/a2a-handler)](https://pypi.org/project/a2a-handler/)
-[![PyPI downloads](https://img.shields.io/pypi/dm/a2a-handler)](https://pypi.org/project/a2a-handler/)
+[![PyPI monthly downloads](https://img.shields.io/pypi/dm/a2a-handler)](https://pypi.org/project/a2a-handler/)
+[![Pepy total downloads](https://img.shields.io/pepy/dt/a2a-handler?label=total%20downloads)](https://pepy.tech/projects/a2a-handler)
 [![GitHub stars](https://img.shields.io/github/stars/alDuncanson/handler)](https://github.com/alDuncanson/handler/stargazers)
 
 An [A2A](https://github.com/a2aproject/A2A) Protocol client TUI and CLI.

--- a/docs/build.ts
+++ b/docs/build.ts
@@ -1,32 +1,26 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
 
 const srcDir = join(import.meta.dir, "src");
-const outDir = join(import.meta.dir, "dist");
+const distDir = join(import.meta.dir, "dist");
 
-async function build() {
-  await mkdir(outDir, { recursive: true });
+const html = readFileSync(join(srcDir, "index.html"), "utf-8");
+const css = readFileSync(join(srcDir, "style.css"), "utf-8");
+const js = readFileSync(join(srcDir, "theme.js"), "utf-8");
 
-  const html = await readFile(join(srcDir, "index.html"), "utf-8");
-  const css = await readFile(join(srcDir, "style.css"), "utf-8");
-  const js = await readFile(join(srcDir, "theme.js"), "utf-8");
+const inlined = html
+  .replace(
+    '<link rel="stylesheet" href="style.css">',
+    `<style>${css}</style>`
+  )
+  .replace(
+    '<script src="theme.js"></script>',
+    `<script>${js}</script>`
+  );
 
-  const inlined = html
-    .replace(
-      '<link rel="stylesheet" href="style.css">',
-      `<style>${css}</style>`
-    )
-    .replace(
-      '<script src="theme.js"></script>',
-      `<script>${js}</script>`
-    );
-
-  await writeFile(join(outDir, "index.html"), inlined);
-
-  console.log("Built docs/dist/index.html");
+if (!existsSync(distDir)) {
+  mkdirSync(distDir, { recursive: true });
 }
 
-build().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+writeFileSync(join(distDir, "index.html"), inlined);
+console.log("Built docs/dist/index.html");

--- a/docs/build.ts
+++ b/docs/build.ts
@@ -1,0 +1,32 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+
+const srcDir = join(import.meta.dir, "src");
+const outDir = join(import.meta.dir, "dist");
+
+async function build() {
+  await mkdir(outDir, { recursive: true });
+
+  const html = await readFile(join(srcDir, "index.html"), "utf-8");
+  const css = await readFile(join(srcDir, "style.css"), "utf-8");
+  const js = await readFile(join(srcDir, "theme.js"), "utf-8");
+
+  const inlined = html
+    .replace(
+      '<link rel="stylesheet" href="style.css">',
+      `<style>${css}</style>`
+    )
+    .replace(
+      '<script src="theme.js"></script>',
+      `<script>${js}</script>`
+    );
+
+  await writeFile(join(outDir, "index.html"), inlined);
+
+  console.log("Built docs/dist/index.html");
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -11,7 +11,7 @@
     <div class="header-content">
       <h1>Handler</h1>
       <p class="tagline">An A2A Protocol client TUI and CLI</p>
-      <button id="theme-toggle" aria-label="Toggle dark mode">☀️</button>
+      <button id="theme-toggle" aria-label="Toggle dark mode"></button>
     </div>
   </header>
 

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Handler Documentation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Handler</h1>
+      <p class="tagline">An A2A Protocol client TUI and CLI</p>
+      <button id="theme-toggle" aria-label="Toggle dark mode">☀️</button>
+    </div>
+  </header>
+
+  <nav>
+    <ul>
+      <li><a href="#install">Install</a></li>
+      <li><a href="#message">Messages</a></li>
+      <li><a href="#task">Tasks</a></li>
+      <li><a href="#card">Agent Cards</a></li>
+      <li><a href="#server">Servers</a></li>
+      <li><a href="#session">Sessions</a></li>
+      <li><a href="#auth">Authentication</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#tui">TUI</a></li>
+      <li><a href="#web">Web</a></li>
+    </ul>
+  </nav>
+
+  <main>
+    <section id="install">
+      <h2>Installation</h2>
+      <p>Install Handler using <a href="https://github.com/astral-sh/uv">uv</a>:</p>
+      <pre><code>uv tool install a2a-handler</code></pre>
+      <p>Or run in an ephemeral environment:</p>
+      <pre><code>uvx --from a2a-handler handler</code></pre>
+      <p>For a full list of commands and options:</p>
+      <pre><code>handler --help</code></pre>
+    </section>
+
+    <section id="message">
+      <h2>Messages</h2>
+      <p>Send messages to A2A agents and receive responses.</p>
+
+      <h3>handler message send</h3>
+      <p>Send a message to an agent and receive a response.</p>
+      <pre><code>handler message send &lt;agent_url&gt; &lt;text&gt; [options]</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the A2A agent to send the message to.</dd>
+        <dt><code>text</code></dt>
+        <dd>The message text to send.</dd>
+      </dl>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--stream, -s</code></dt>
+        <dd>Stream responses in real-time.</dd>
+        <dt><code>--context-id</code></dt>
+        <dd>Context ID for conversation continuity.</dd>
+        <dt><code>--task-id</code></dt>
+        <dd>Task ID to continue.</dd>
+        <dt><code>--continue, -C</code></dt>
+        <dd>Continue from saved session state.</dd>
+        <dt><code>--push-url</code></dt>
+        <dd>Webhook URL for push notifications.</dd>
+        <dt><code>--push-token</code></dt>
+        <dd>Authentication token for push notifications.</dd>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token for authentication (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key for authentication (overrides saved credentials).</dd>
+      </dl>
+      <h4>Examples</h4>
+      <pre><code># Basic message
+handler message send http://localhost:8000 "What can you help me with?"
+
+# Continue a conversation
+handler message send http://localhost:8000 "Follow up question" --continue
+
+# With push notifications
+handler message send http://localhost:8000 "hello" --push-url http://localhost:9000/webhook</code></pre>
+
+      <h3>handler message stream</h3>
+      <p>Send a message and stream the response in real-time. This is equivalent to <code>handler message send --stream</code>.</p>
+      <pre><code>handler message stream &lt;agent_url&gt; &lt;text&gt; [options]</code></pre>
+      <h4>Example</h4>
+      <pre><code>handler message stream http://localhost:8000 "Tell me a story"</code></pre>
+    </section>
+
+    <section id="task">
+      <h2>Tasks</h2>
+      <p>Manage A2A tasks including retrieval, cancellation, and push notifications.</p>
+
+      <h3>handler task get</h3>
+      <p>Retrieve the current status of a task.</p>
+      <pre><code>handler task get &lt;agent_url&gt; &lt;task_id&gt; [options]</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the A2A agent.</dd>
+        <dt><code>task_id</code></dt>
+        <dd>The ID of the task to retrieve.</dd>
+      </dl>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--history-length, -n</code></dt>
+        <dd>Number of history messages to include.</dd>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key (overrides saved credentials).</dd>
+      </dl>
+
+      <h3>handler task cancel</h3>
+      <p>Request cancellation of a task.</p>
+      <pre><code>handler task cancel &lt;agent_url&gt; &lt;task_id&gt; [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key (overrides saved credentials).</dd>
+      </dl>
+
+      <h3>handler task resubscribe</h3>
+      <p>Resubscribe to a task's SSE stream after disconnection.</p>
+      <pre><code>handler task resubscribe &lt;agent_url&gt; &lt;task_id&gt; [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key (overrides saved credentials).</dd>
+      </dl>
+
+      <h3>handler task notification set</h3>
+      <p>Configure a push notification webhook for a task.</p>
+      <pre><code>handler task notification set &lt;agent_url&gt; &lt;task_id&gt; --url &lt;webhook_url&gt; [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--url, -u</code> (required)</dt>
+        <dd>Webhook URL to receive notifications.</dd>
+        <dt><code>--token, -t</code></dt>
+        <dd>Authentication token for the webhook.</dd>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key (overrides saved credentials).</dd>
+      </dl>
+
+      <h3>handler task notification get</h3>
+      <p>Get the push notification configuration for a task.</p>
+      <pre><code>handler task notification get &lt;agent_url&gt; &lt;task_id&gt; [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--config-id, -c</code></dt>
+        <dd>Specific push notification config ID.</dd>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token (overrides saved credentials).</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key (overrides saved credentials).</dd>
+      </dl>
+    </section>
+
+    <section id="card">
+      <h2>Agent Cards</h2>
+      <p>Retrieve and validate A2A agent cards.</p>
+
+      <h3>handler card get</h3>
+      <p>Retrieve an agent's card and display it as JSON.</p>
+      <pre><code>handler card get &lt;agent_url&gt; [options]</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the A2A agent.</dd>
+      </dl>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--authenticated, -a</code></dt>
+        <dd>Request authenticated extended card.</dd>
+      </dl>
+      <h4>Example</h4>
+      <pre><code>handler card get http://localhost:8000</code></pre>
+
+      <h3>handler card validate</h3>
+      <p>Validate an agent card from a URL or local file.</p>
+      <pre><code>handler card validate &lt;source&gt;</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>source</code></dt>
+        <dd>URL of an agent or path to a local agent card JSON file.</dd>
+      </dl>
+      <h4>Examples</h4>
+      <pre><code># Validate from URL
+handler card validate http://localhost:8000
+
+# Validate from file
+handler card validate ./agent-card.json</code></pre>
+    </section>
+
+    <section id="server">
+      <h2>Servers</h2>
+      <p>Run local A2A servers for development and testing.</p>
+
+      <h3>handler server agent</h3>
+      <p>Start a local A2A agent server. This is a reference implementation built with <a href="https://github.com/google/adk-python">Google ADK</a> and <a href="https://github.com/BerriAI/litellm">LiteLLM</a>, connecting to <a href="https://github.com/ollama/ollama">Ollama</a> for local inference.</p>
+      <pre><code>handler server agent [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--host</code></dt>
+        <dd>Host to bind to. Default: <code>0.0.0.0</code></dd>
+        <dt><code>--port</code></dt>
+        <dd>Port to bind to. Default: <code>8000</code></dd>
+        <dt><code>--auth / --no-auth</code></dt>
+        <dd>Require API key authentication. Default: <code>--no-auth</code></dd>
+        <dt><code>--api-key</code></dt>
+        <dd>Specific API key to use. If not set, one is auto-generated when <code>--auth</code> is enabled.</dd>
+        <dt><code>--model, -m</code></dt>
+        <dd>Model to use (e.g., <code>llama3.2:1b</code>, <code>qwen3</code>, <code>gemini-2.0-flash</code>). Use any model from <a href="https://ollama.com/library">Ollama's library</a>.</dd>
+      </dl>
+      <h4>Examples</h4>
+      <pre><code># Basic server
+handler server agent
+
+# With a specific model
+handler server agent --model llama3.2:1b
+
+# With authentication
+handler server agent --auth</code></pre>
+      <p><strong>Note:</strong> Handler will prompt to pull missing models automatically.</p>
+
+      <h3>handler server push</h3>
+      <p>Start a local webhook server for receiving push notifications from A2A agents.</p>
+      <pre><code>handler server push [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--host</code></dt>
+        <dd>Host to bind to. Default: <code>127.0.0.1</code></dd>
+        <dt><code>--port</code></dt>
+        <dd>Port to bind to. Default: <code>9000</code></dd>
+      </dl>
+      <h4>Example</h4>
+      <pre><code># Start webhook server
+handler server push
+
+# Send a message with push notifications
+handler message send http://localhost:8000 "hello" --push-url http://localhost:9000/webhook</code></pre>
+    </section>
+
+    <section id="session">
+      <h2>Sessions</h2>
+      <p>Manage saved session state for maintaining conversation context across commands.</p>
+
+      <h3>handler session list</h3>
+      <p>List all saved sessions.</p>
+      <pre><code>handler session list</code></pre>
+
+      <h3>handler session show</h3>
+      <p>Display session state for a specific agent.</p>
+      <pre><code>handler session show &lt;agent_url&gt;</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the A2A agent.</dd>
+      </dl>
+
+      <h3>handler session clear</h3>
+      <p>Clear saved session state.</p>
+      <pre><code>handler session clear [agent_url] [options]</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the agent to clear. Optional if using <code>--all</code>.</dd>
+      </dl>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--all, -a</code></dt>
+        <dd>Clear all saved sessions.</dd>
+      </dl>
+      <h4>Examples</h4>
+      <pre><code># Clear session for one agent
+handler session clear http://localhost:8000
+
+# Clear all sessions
+handler session clear --all</code></pre>
+    </section>
+
+    <section id="auth">
+      <h2>Authentication</h2>
+      <p>Manage authentication credentials for A2A agents.</p>
+
+      <h3>handler auth set</h3>
+      <p>Set authentication credentials for an agent. Provide either <code>--bearer</code> or <code>--api-key</code> (not both).</p>
+      <pre><code>handler auth set &lt;agent_url&gt; [options]</code></pre>
+      <h4>Arguments</h4>
+      <dl>
+        <dt><code>agent_url</code></dt>
+        <dd>The URL of the A2A agent.</dd>
+      </dl>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--bearer, -b</code></dt>
+        <dd>Bearer token for authentication.</dd>
+        <dt><code>--api-key, -k</code></dt>
+        <dd>API key for authentication.</dd>
+        <dt><code>--api-key-header</code></dt>
+        <dd>Header name for API key. Default: <code>X-API-Key</code></dd>
+      </dl>
+      <h4>Examples</h4>
+      <pre><code># Set API key
+handler auth set http://localhost:8000 --api-key my-secret
+
+# Set bearer token
+handler auth set https://api.example.com --bearer eyJhbG...</code></pre>
+
+      <h3>handler auth show</h3>
+      <p>Show authentication credentials for an agent (values are masked).</p>
+      <pre><code>handler auth show &lt;agent_url&gt;</code></pre>
+
+      <h3>handler auth clear</h3>
+      <p>Clear authentication credentials for an agent.</p>
+      <pre><code>handler auth clear &lt;agent_url&gt;</code></pre>
+    </section>
+
+    <section id="mcp">
+      <h2>MCP Server</h2>
+      <p>Run a local <a href="https://modelcontextprotocol.io/">Model Context Protocol (MCP)</a> server exposing Handler's A2A functionality as MCP tools and resources.</p>
+
+      <h3>handler mcp</h3>
+      <p>Start an MCP server that can be connected to from any MCP-compatible client (Claude Desktop, Cursor, etc.).</p>
+      <pre><code>handler mcp [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--transport, -t</code></dt>
+        <dd>Transport protocol to use. Choices: <code>stdio</code>, <code>sse</code>, <code>streamable-http</code>. Default: <code>stdio</code></dd>
+      </dl>
+
+      <h4>Available Tools</h4>
+      <p>The MCP server exposes the following tools:</p>
+      <h5>Card Tools</h5>
+      <ul>
+        <li><code>validate_agent_card</code> – Validate an agent card from URL or file</li>
+        <li><code>get_agent_card</code> – Retrieve an agent's full card details</li>
+      </ul>
+      <h5>Message Tools</h5>
+      <ul>
+        <li><code>send_message</code> – Send messages to agents with session/auth support</li>
+      </ul>
+      <h5>Task Tools</h5>
+      <ul>
+        <li><code>get_task</code> – Get task status and details</li>
+        <li><code>cancel_task</code> – Cancel a running task</li>
+        <li><code>set_task_notification</code> – Configure push notification webhooks</li>
+        <li><code>get_task_notification</code> – Get push notification config</li>
+      </ul>
+      <h5>Session Tools</h5>
+      <ul>
+        <li><code>list_sessions</code> – List all saved sessions</li>
+        <li><code>get_session_info</code> – Get session for a specific agent</li>
+        <li><code>clear_session_data</code> – Clear saved session state</li>
+      </ul>
+      <h5>Auth Tools</h5>
+      <ul>
+        <li><code>set_agent_credentials</code> – Save bearer token or API key</li>
+        <li><code>clear_agent_credentials</code> – Remove saved credentials</li>
+      </ul>
+
+      <h4>Claude Desktop Configuration</h4>
+      <p>Add this to your <code>claude_desktop_config.json</code>:</p>
+      <pre><code>{
+  "mcpServers": {
+    "handler": {
+      "command": "handler",
+      "args": ["mcp"]
+    }
+  }
+}</code></pre>
+    </section>
+
+    <section id="tui">
+      <h2>Terminal User Interface</h2>
+      <p>Handler includes an interactive terminal interface for working with A2A agents.</p>
+
+      <h3>handler tui</h3>
+      <p>Launch the interactive terminal interface.</p>
+      <pre><code>handler tui</code></pre>
+
+      <div class="screenshot-placeholder">
+        <p><em>Screenshot placeholder: Add TUI screenshot here</em></p>
+      </div>
+
+      <h4>Features</h4>
+      <ul>
+        <li>Connect to multiple A2A agents</li>
+        <li>Send messages and view responses</li>
+        <li>Stream responses in real-time</li>
+        <li>Manage sessions and authentication</li>
+        <li>View agent cards</li>
+      </ul>
+    </section>
+
+    <section id="web">
+      <h2>Web Interface</h2>
+      <p>Serve the TUI as a web application accessible in your browser.</p>
+
+      <h3>handler web</h3>
+      <p>Start a web server that serves the TUI interface.</p>
+      <pre><code>handler web [options]</code></pre>
+      <h4>Options</h4>
+      <dl>
+        <dt><code>--host</code></dt>
+        <dd>Host to bind to. Default: <code>localhost</code></dd>
+        <dt><code>--port, -p</code></dt>
+        <dd>Port to bind to. Default: <code>8001</code></dd>
+      </dl>
+      <h4>Example</h4>
+      <pre><code>handler web --port 3000</code></pre>
+    </section>
+
+    <section id="global-options">
+      <h2>Global Options</h2>
+      <p>These options are available for all commands:</p>
+      <dl>
+        <dt><code>--verbose, -v</code></dt>
+        <dd>Enable verbose logging.</dd>
+        <dt><code>--debug, -d</code></dt>
+        <dd>Enable debug logging.</dd>
+      </dl>
+    </section>
+
+    <section id="version">
+      <h2>Version</h2>
+      <h3>handler version</h3>
+      <p>Display the current Handler version.</p>
+      <pre><code>handler version</code></pre>
+    </section>
+  </main>
+
+  <footer>
+    <p>Handler – <a href="https://github.com/alDuncanson/handler">GitHub</a> – <a href="https://pypi.org/project/a2a-handler/">PyPI</a></p>
+  </footer>
+
+  <script src="theme.js"></script>
+</body>
+</html>

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -18,6 +18,7 @@
   <nav>
     <ul>
       <li><a href="#install">Install</a></li>
+      <li><a href="#global-options">Options</a></li>
       <li><a href="#message">Messages</a></li>
       <li><a href="#task">Tasks</a></li>
       <li><a href="#card">Agent Cards</a></li>
@@ -39,6 +40,17 @@
       <pre><code>uvx --from a2a-handler handler</code></pre>
       <p>For a full list of commands and options:</p>
       <pre><code>handler --help</code></pre>
+    </section>
+
+    <section id="global-options">
+      <h2>Global Options</h2>
+      <p>These options are available for all commands:</p>
+      <dl>
+        <dt><code>--verbose, -v</code></dt>
+        <dd>Enable verbose logging.</dd>
+        <dt><code>--debug, -d</code></dt>
+        <dd>Enable debug logging.</dd>
+      </dl>
     </section>
 
     <section id="message">
@@ -419,17 +431,6 @@ handler auth set https://api.example.com --bearer eyJhbG...</code></pre>
       </dl>
       <h4>Example</h4>
       <pre><code>handler web --port 3000</code></pre>
-    </section>
-
-    <section id="global-options">
-      <h2>Global Options</h2>
-      <p>These options are available for all commands:</p>
-      <dl>
-        <dt><code>--verbose, -v</code></dt>
-        <dd>Enable verbose logging.</dd>
-        <dt><code>--debug, -d</code></dt>
-        <dd>Enable debug logging.</dd>
-      </dl>
     </section>
 
     <section id="version">

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -1,0 +1,240 @@
+:root {
+  --bg: #fff;
+  --text: #222;
+  --text-muted: #555;
+  --link: #0066cc;
+  --code-bg: #f5f5f5;
+  --border: #ddd;
+  --header-bg: #fafafa;
+}
+
+[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --text: #e0e0e0;
+  --text-muted: #999;
+  --link: #6699ff;
+  --code-bg: #2a2a2a;
+  --border: #444;
+  --header-bg: #222;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: Georgia, "Times New Roman", Times, serif;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border);
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.header-content {
+  max-width: 800px;
+  margin: 0 auto;
+  position: relative;
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.5rem;
+  font-weight: normal;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+#theme-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: none;
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 1.2rem;
+}
+
+nav {
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 100;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+nav a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+section {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+section:last-child {
+  border-bottom: none;
+}
+
+h2 {
+  font-weight: normal;
+  font-size: 1.75rem;
+  margin: 0 0 1rem;
+  padding-top: 1rem;
+}
+
+h3 {
+  font-weight: normal;
+  font-size: 1.25rem;
+  margin: 2rem 0 0.75rem;
+  color: var(--text);
+}
+
+h4 {
+  font-weight: normal;
+  font-size: 1rem;
+  margin: 1.5rem 0 0.5rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+h5 {
+  font-weight: bold;
+  font-size: 0.9rem;
+  margin: 1rem 0 0.5rem;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+a {
+  color: var(--link);
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 4px;
+  margin: 0 0 1rem;
+}
+
+code {
+  font-family: "SF Mono", Monaco, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+:not(pre) > code {
+  background: var(--code-bg);
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+}
+
+dl {
+  margin: 0 0 1rem;
+}
+
+dt {
+  margin-top: 0.75rem;
+}
+
+dt code {
+  font-weight: bold;
+}
+
+dd {
+  margin: 0.25rem 0 0 1.5rem;
+  color: var(--text-muted);
+}
+
+ul {
+  margin: 0 0 1rem;
+  padding-left: 1.5rem;
+}
+
+li {
+  margin-bottom: 0.25rem;
+}
+
+.screenshot-placeholder {
+  background: var(--code-bg);
+  border: 2px dashed var(--border);
+  padding: 2rem;
+  text-align: center;
+  margin: 1rem 0;
+  border-radius: 4px;
+}
+
+.screenshot-placeholder p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+footer p {
+  margin: 0;
+}
+
+@media (max-width: 600px) {
+  header h1 {
+    font-size: 2rem;
+  }
+
+  nav ul {
+    gap: 0.5rem;
+  }
+
+  #theme-toggle {
+    position: static;
+    margin-top: 1rem;
+  }
+}

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -70,6 +70,7 @@ header h1 {
   cursor: pointer;
   border-radius: 4px;
   font-size: 1.2rem;
+  color: var(--text);
 }
 
 nav {

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -113,6 +113,7 @@ section {
   margin-bottom: 3rem;
   padding-bottom: 2rem;
   border-bottom: 1px solid var(--border);
+  scroll-margin-top: 3.5rem;
 }
 
 section:last-child {
@@ -124,6 +125,7 @@ h2 {
   font-size: 1.75rem;
   margin: 0 0 1rem;
   padding-top: 1rem;
+  scroll-margin-top: 4rem;
 }
 
 h3 {

--- a/docs/src/theme.js
+++ b/docs/src/theme.js
@@ -1,0 +1,19 @@
+const toggle = document.getElementById('theme-toggle');
+const html = document.documentElement;
+
+const stored = localStorage.getItem('theme');
+if (stored) {
+  html.setAttribute('data-theme', stored);
+  toggle.textContent = stored === 'dark' ? '\u2600' : '\u263D';
+} else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  html.setAttribute('data-theme', 'dark');
+  toggle.textContent = '\u2600';
+}
+
+toggle.addEventListener('click', () => {
+  const current = html.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  html.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
+  toggle.textContent = next === 'dark' ? '\u2600' : '\u263D';
+});

--- a/docs/src/theme.js
+++ b/docs/src/theme.js
@@ -8,6 +8,8 @@ if (stored) {
 } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
   html.setAttribute('data-theme', 'dark');
   toggle.textContent = '\u2600';
+} else {
+  toggle.textContent = '\u263D';
 }
 
 toggle.addEventListener('click', () => {

--- a/justfile
+++ b/justfile
@@ -70,3 +70,15 @@ tag:
 # Tag and push the release to origin
 release: tag
     git push origin "v$(uv version --short)"
+
+# Build docs for production
+docs-build:
+    bun build docs/src/index.html --outdir docs/dist --minify
+
+# Serve docs locally for development
+docs-dev:
+    bun docs/src/index.html
+
+# Preview production docs build
+docs-preview: docs-build
+    uv run python -m http.server -d docs/dist 8080


### PR DESCRIPTION
This pull request introduces a documentation site with a custom build pipeline, adds a dark mode theme toggle, and updates project documentation and badges. The main changes include a new workflow for deploying documentation, a Bun-based static site builder, and improvements to the documentation's look and feel.

**Documentation Build and Deployment:**
- Added a GitHub Actions workflow (`.github/workflows/docs.yml`) to automatically build and deploy the documentation site on pushes to `main` or via manual dispatch. Uses Bun for building and deploys to GitHub Pages.
- Introduced a Bun-based build script (`docs/build.ts`) that inlines CSS and JS into the HTML for a single-file static site build.
- Updated `justfile` with tasks for building, serving, and previewing the documentation locally and in production.

**Documentation Site Features:**
- Added a custom CSS theme (`docs/src/style.css`) supporting light and dark modes, responsive layout, and improved typography for better readability.
- Implemented a JavaScript theme toggle (`docs/src/theme.js`) that allows users to switch between light and dark modes, storing the preference in local storage and using Unicode symbols for the toggle button.

**Project Documentation Updates:**
- Updated badges in `README.md` to show monthly and total downloads, improving project visibility.
- Added a new guideline in `AGENTS.md` to use Unicode symbols instead of emojis in code, documentation, comments, and UI.