### PR TITLE
SSL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "uvicorn>=0.30.0",
     "textual-serve>=1.1.0",
     "mcp[cli]>=1.2.0",
+    "truststore>=0.9.0",
 ]
 
 [dependency-groups]

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -9,6 +9,10 @@ Provides commands for interacting with A2A agents:
 - session list/show/clear: Manage saved sessions
 """
 
+import truststore
+
+truststore.inject_into_ssl()
+
 import logging
 
 logging.getLogger().setLevel(logging.WARNING)

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
     { name = "rich-click" },
     { name = "textual" },
     { name = "textual-serve" },
+    { name = "truststore" },
     { name = "uvicorn" },
 ]
 
@@ -49,6 +50,7 @@ requires-dist = [
     { name = "rich-click", specifier = ">=1.8.0" },
     { name = "textual", specifier = ">=0.47.0" },
     { name = "textual-serve", specifier = ">=1.1.0" },
+    { name = "truststore", specifier = ">=0.9.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
@@ -3266,6 +3268,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces improved SSL certificate handling for the CLI by adding the `truststore` dependency and ensuring it is used at runtime. This change helps standardize and enhance SSL verification, particularly in environments where the default certificate store may be incomplete or inconsistent.

Dependency management:

* Added `truststore>=0.9.0` to the dependencies list in `pyproject.toml` to ensure the package is installed.

Runtime SSL configuration:

* Imported the `truststore` package and called `truststore.inject_into_ssl()` at the start of the CLI module (`src/a2a_handler/cli/__init__.py`) to ensure Python uses the system certificate store for SSL connections.