### PR TITLE
feat: add docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ handler message send URL "hello"         # send a message from the CLI
 handler card get URL                     # fetch an agent card
 handler mcp                              # start the MCP server
 handler server run agent                 # run the bundled reference agent
+handler docs                             # open the hosted documentation
 ```
 
 ## Run Without Installing

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -38,6 +38,7 @@ handler message send URL "hello"
 handler card get URL
 handler mcp
 handler server run agent
+handler docs
 ```
 
 ## What to read next

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -84,8 +84,14 @@ See [MCP server](./guides/mcp) for transport options and client setup.
 
 ## Preview these docs locally
 
-Install the Mintlify CLI, then run the preview server from the `docs/`
-directory where `docs.json` lives:
+To open the deployed docs in your browser from the CLI:
+
+```bash
+handler docs
+```
+
+To preview local documentation changes, install the Mintlify CLI, then run the
+preview server from the `docs/` directory where `docs.json` lives.
 
 ```bash
 npm i -g mint

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -19,6 +19,7 @@ truststore.inject_into_ssl()
 
 import logging
 import os
+import webbrowser
 
 logging.getLogger().setLevel(logging.WARNING)
 
@@ -39,6 +40,8 @@ from .session import session
 from .task import task
 
 log = get_logger(__name__)
+
+DOCS_URL = "https://handler.alduncanson.com/"
 
 
 @click.group()
@@ -101,6 +104,19 @@ def version() -> None:
     """
     output = Output()
     output.json({"version": __version__})
+
+
+@cli.command()
+def docs() -> None:
+    """Open the Handler documentation in your browser.
+
+    \b
+    Examples:
+      $ handler docs
+    """
+    opened = webbrowser.open(DOCS_URL)
+    output = Output()
+    output.json({"url": DOCS_URL, "opened": opened})
 
 
 @cli.command()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -70,3 +70,14 @@ def test_version_output(runner: CliRunner) -> None:
 
     assert result.exit_code == 0
     assert '"version"' in result.output
+
+
+def test_docs_opens_deployed_documentation(runner: CliRunner) -> None:
+    """Docs command opens the hosted documentation URL."""
+    with patch("a2a_handler.cli.webbrowser.open", return_value=True) as mock_open:
+        result = runner.invoke(cli, ["docs"])
+
+    assert result.exit_code == 0
+    mock_open.assert_called_once_with("https://handler.alduncanson.com/")
+    assert '"url": "https://handler.alduncanson.com/"' in result.output
+    assert '"opened": true' in result.output


### PR DESCRIPTION
This pull request introduces a new CLI command, `handler docs`, that opens the hosted Handler documentation in your browser. The command is documented in both the CLI help and the user documentation, and a test has been added to ensure it works as expected.

**New CLI command for accessing documentation:**

* Added a `docs` command to the CLI (`src/a2a_handler/cli/__init__.py`), which opens the hosted documentation URL in the user's browser and outputs the URL and whether it was successfully opened. [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R22) [[2]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R44-R45) [[3]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R109-R121)

**Documentation updates:**

* Updated the `README.md`, `docs/index.mdx`, and `docs/quickstart.mdx` files to include the new `handler docs` command, making it easier for users to discover and access the documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[2]](diffhunk://#diff-135108c7d936a6d1e05ce4ecaa854c5dccdea8ad5d317e08d61639b9ffbc6425R41) [[3]](diffhunk://#diff-f1db7c587c0fc6ae7a362a3b0b9bd308c4b8efa4687f14f248abd72b09ebd58bL87-R94)

**Testing:**

* Added a test to verify that the `docs` command opens the correct URL and outputs the expected result.