### PR TITLE
chore: update reference agent model

### DIFF
--- a/docs/guides/local-servers.mdx
+++ b/docs/guides/local-servers.mdx
@@ -26,18 +26,18 @@ endpoint.
 You can override the model directly:
 
 ```bash
-handler server run agent --model qwen3
+handler server run agent --model gemma4:e4b
 ```
 
 Or set environment variables:
 
 ```bash
-export OLLAMA_MODEL=llama3.2:3b
+export OLLAMA_MODEL=gemma4:e2b
 export OLLAMA_API_BASE=http://localhost:11434
 handler server run agent
 ```
 
-If you do not override it, Handler defaults to `llama3.2:1b` and
+If you do not override it, Handler defaults to `gemma4:e2b` and
 `http://localhost:11434`.
 
 ## Protect the local agent with an API key

--- a/src/a2a_handler/cli/server.py
+++ b/src/a2a_handler/cli/server.py
@@ -626,7 +626,7 @@ def server_run() -> None:
     "--model",
     "-m",
     default=None,
-    help="Model to use (e.g., 'llama3.2:1b', 'qwen3', 'gemini-2.0-flash')",
+    help="Model to use (e.g., 'gemma4:e2b', 'qwen3', 'gemini-2.0-flash')",
 )
 def server_agent(
     host: str,
@@ -642,7 +642,7 @@ def server_agent(
       $ handler server run agent
       $ handler server run agent --port 9000
       $ handler server run agent --auth --api-key my-secret
-      $ handler server run agent --model gemini-2.0-flash
+      $ handler server run agent --model gemma4:e4b
     """
     log.info("Starting A2A server on %s:%d", host, port)
     run_server(

--- a/src/a2a_handler/server/__init__.py
+++ b/src/a2a_handler/server/__init__.py
@@ -33,7 +33,7 @@ def run_server(
         port: Port number to bind to
         require_auth: Whether to require API key authentication
         api_key: Specific API key to use (generated if not provided and auth required)
-        model: Ollama model identifier (e.g., 'llama3.2:1b')
+        model: Ollama model identifier (e.g., 'gemma4:e2b')
     """
     effective_model = model or os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
 

--- a/src/a2a_handler/server/agent.py
+++ b/src/a2a_handler/server/agent.py
@@ -11,7 +11,7 @@ from a2a_handler.common.dotenv import load_runtime_dotenv
 logger = get_logger(__name__)
 
 DEFAULT_OLLAMA_API_BASE = "http://localhost:11434"
-DEFAULT_OLLAMA_MODEL = "llama3.2:1b"
+DEFAULT_OLLAMA_MODEL = "gemma4:e2b"
 
 
 def create_language_model(model: str | None = None) -> LiteLlm:
@@ -44,7 +44,7 @@ def create_llm_agent(model: str | None = None) -> Agent:
     """Create and configure the A2A agent using Ollama via LiteLLM.
 
     Args:
-        model: Ollama model identifier (e.g., 'llama3.2:1b')
+        model: Ollama model identifier (e.g., 'gemma4:e2b')
 
     Returns:
         Configured ADK Agent instance

--- a/tests/server/test_ollama.py
+++ b/tests/server/test_ollama.py
@@ -14,12 +14,12 @@ class TestGetOllamaModels:
         """Test successful parsing of ollama list output."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="NAME\nllama3.2:latest\ngemma:7b\n",
+            stdout="NAME\ngemma4:e2b\ngemma4:e4b\n",
         )
 
         models = get_ollama_models()
 
-        assert models == ["llama3.2:latest", "gemma:7b"]
+        assert models == ["gemma4:e2b", "gemma4:e4b"]
         mock_run.assert_called_once_with(
             ["ollama", "list"],
             capture_output=True,
@@ -70,20 +70,20 @@ class TestCheckOllamaModel:
     @patch("a2a_handler.server.ollama.get_ollama_models")
     def test_check_ollama_model_found(self, mock_get_models):
         """Test model is found when it matches exactly."""
-        mock_get_models.return_value = ["llama3.2:latest", "gemma:7b"]
+        mock_get_models.return_value = ["gemma4:e2b", "gemma4:e4b"]
 
-        assert check_ollama_model("llama3.2:latest") is True
+        assert check_ollama_model("gemma4:e2b") is True
 
     @patch("a2a_handler.server.ollama.get_ollama_models")
     def test_check_ollama_model_not_found(self, mock_get_models):
         """Test model is not found."""
-        mock_get_models.return_value = ["llama3.2:latest", "gemma:7b"]
+        mock_get_models.return_value = ["gemma4:e2b", "gemma4:e4b"]
 
         assert check_ollama_model("mistral:latest") is False
 
     @patch("a2a_handler.server.ollama.get_ollama_models")
     def test_check_ollama_model_matches_base_name(self, mock_get_models):
         """Test model matches by base name prefix."""
-        mock_get_models.return_value = ["llama3.2:latest"]
+        mock_get_models.return_value = ["gemma4:e4b"]
 
-        assert check_ollama_model("llama3.2:1b") is True
+        assert check_ollama_model("gemma4:e2b") is True


### PR DESCRIPTION
This pull request updates the default Ollama model used throughout the codebase and documentation from `llama3.2:1b` to `gemma4:e2b`. It also updates code comments, help texts, and tests to reflect this new default, ensuring consistency for users and developers.

**Default model update:**

* Changed the default Ollama model from `llama3.2:1b` to `gemma4:e2b` in `DEFAULT_OLLAMA_MODEL` in `src/a2a_handler/server/agent.py`, and updated all related docstrings and comments to refer to the new model. [[1]](diffhunk://#diff-e74901493dd6252dc39e95443766534d96d3b86c97083a329001060d422ded46L14-R14) [[2]](diffhunk://#diff-e74901493dd6252dc39e95443766534d96d3b86c97083a329001060d422ded46L47-R47) [[3]](diffhunk://#diff-841d82c1a8fe08e4bc361ba5b5049ebb7084e23841add2719fca5ca5e12f05eaL36-R36)

**Documentation and CLI help updates:**

* Updated documentation in `docs/guides/local-servers.mdx` to use `gemma4:e2b` as the default and in example commands, replacing references to `llama3.2:1b`.
* Updated CLI help text and usage examples in `src/a2a_handler/cli/server.py` to use the new model in both the help message and sample commands. [[1]](diffhunk://#diff-bada2072eb9614448a31e7a3c73280f0fc50a0a40d0c88077f71b2bb215f3c7eL629-R629) [[2]](diffhunk://#diff-bada2072eb9614448a31e7a3c73280f0fc50a0a40d0c88077f71b2bb215f3c7eL645-R645)

**Test updates:**

* Modified tests in `tests/server/test_ollama.py` to use `gemma4:e2b` and `gemma4:e4b` as the available models, updating assertions and mock returns accordingly. [[1]](diffhunk://#diff-3a9edc607630d9994bd4c683e328d86a2cb52a020ea0994f0a6ebd4ee6313363L17-R22) [[2]](diffhunk://#diff-3a9edc607630d9994bd4c683e328d86a2cb52a020ea0994f0a6ebd4ee6313363L73-R89)