### PR TITLE
feat: add update command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ handler card get URL                     # fetch an agent card
 handler mcp                              # start the MCP server
 handler server run agent                 # run the bundled reference agent
 handler docs                             # open the hosted documentation
+handler update                           # upgrade Handler to the latest release
 ```
 
 ## Run Without Installing

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -39,6 +39,7 @@ handler card get URL
 handler mcp
 handler server run agent
 handler docs
+handler update
 ```
 
 ## What to read next

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,6 +17,14 @@ If you prefer not to install it globally, you can run it directly:
 uvx --from a2a-handler handler --help
 ```
 
+To update an installed Handler later:
+
+```bash
+handler update
+# or
+handler upgrade
+```
+
 ## Start with the TUI
 
 ```bash

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -19,6 +19,8 @@ truststore.inject_into_ssl()
 
 import logging
 import os
+import shutil
+import subprocess
 import webbrowser
 
 logging.getLogger().setLevel(logging.WARNING)
@@ -42,6 +44,7 @@ from .task import task
 log = get_logger(__name__)
 
 DOCS_URL = "https://handler.alduncanson.com/"
+PACKAGE_NAME = "a2a-handler"
 
 
 @click.group()
@@ -117,6 +120,53 @@ def docs() -> None:
     opened = webbrowser.open(DOCS_URL)
     output = Output()
     output.json({"url": DOCS_URL, "opened": opened})
+
+
+def _upgrade_command() -> list[str] | None:
+    """Return the preferred package manager command for upgrading Handler."""
+    if shutil.which("uv"):
+        return ["uv", "tool", "upgrade", PACKAGE_NAME]
+    if shutil.which("pipx"):
+        return ["pipx", "upgrade", PACKAGE_NAME]
+    return None
+
+
+@cli.command()
+def update() -> None:
+    """Update Handler to the latest published version.
+
+    \b
+    Examples:
+      $ handler update
+      $ handler upgrade
+    """
+    output = Output()
+    command = _upgrade_command()
+    if command is None:
+        output.error(
+            code="installer_not_found",
+            message="Could not find uv or pipx to update Handler.",
+            suggestion=(
+                "Install uv or pipx, then run `uv tool upgrade a2a-handler` "
+                "or `pipx upgrade a2a-handler`."
+            ),
+        )
+        raise SystemExit(1)
+
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        output.error(
+            code="update_failed",
+            message="Handler update command failed.",
+            details={
+                "command": command,
+                "returncode": result.returncode,
+            },
+        )
+        raise SystemExit(result.returncode)
+
+
+cli.add_command(update, name="upgrade")
 
 
 @cli.command()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,6 +1,7 @@
 """Tests for top-level CLI commands."""
 
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 from unittest.mock import patch as mock_patch
@@ -81,3 +82,60 @@ def test_docs_opens_deployed_documentation(runner: CliRunner) -> None:
     mock_open.assert_called_once_with("https://handler.alduncanson.com/")
     assert '"url": "https://handler.alduncanson.com/"' in result.output
     assert '"opened": true' in result.output
+
+
+def test_update_uses_uv_when_available(runner: CliRunner) -> None:
+    """Update command uses uv tool upgrade when uv is available."""
+    completed = subprocess.CompletedProcess(
+        args=["uv", "tool", "upgrade", "a2a-handler"],
+        returncode=0,
+        stdout="upgraded\n",
+        stderr="",
+    )
+    with patch("a2a_handler.cli.shutil.which") as mock_which:
+        mock_which.side_effect = lambda name: f"/bin/{name}" if name == "uv" else None
+        with patch(
+            "a2a_handler.cli.subprocess.run", return_value=completed
+        ) as mock_run:
+            result = runner.invoke(cli, ["update"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        ["uv", "tool", "upgrade", "a2a-handler"],
+        check=False,
+    )
+    assert result.output == ""
+
+
+def test_upgrade_alias_uses_pipx_when_uv_is_unavailable(runner: CliRunner) -> None:
+    """Upgrade alias falls back to pipx when uv is unavailable."""
+    completed = subprocess.CompletedProcess(
+        args=["pipx", "upgrade", "a2a-handler"],
+        returncode=0,
+        stdout="upgraded\n",
+        stderr="",
+    )
+    with patch("a2a_handler.cli.shutil.which") as mock_which:
+        mock_which.side_effect = lambda name: f"/bin/{name}" if name == "pipx" else None
+        with patch(
+            "a2a_handler.cli.subprocess.run", return_value=completed
+        ) as mock_run:
+            result = runner.invoke(cli, ["upgrade"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        ["pipx", "upgrade", "a2a-handler"],
+        check=False,
+    )
+    assert result.output == ""
+
+
+def test_update_errors_when_no_supported_installer_is_available(
+    runner: CliRunner,
+) -> None:
+    """Update command reports a helpful error when uv and pipx are missing."""
+    with patch("a2a_handler.cli.shutil.which", return_value=None):
+        result = runner.invoke(cli, ["update"])
+
+    assert result.exit_code == 1
+    assert '"code": "installer_not_found"' in result.output


### PR DESCRIPTION
This pull request adds a convenient self-update command to the Handler CLI, allowing users to upgrade Handler to the latest release using either `uv` or `pipx`. The update is reflected in the CLI implementation, documentation, and comprehensive tests to ensure robust behavior and clear error reporting.

**CLI Enhancements:**

* Added a new `update` command (with `upgrade` as an alias) to the Handler CLI, which automatically detects and uses `uv` or `pipx` to upgrade the installed package. If neither is available, it provides a helpful error message. (`src/a2a_handler/cli/__init__.py` [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R22-R23) [[2]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R47) [[3]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R125-R171)

**Documentation Updates:**

* Updated CLI usage examples in `README.md`, `docs/index.mdx`, and `docs/quickstart.mdx` to document the new `handler update` and `handler upgrade` commands, including how to use them. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39) [[2]](diffhunk://#diff-135108c7d936a6d1e05ce4ecaa854c5dccdea8ad5d317e08d61639b9ffbc6425R42) [[3]](diffhunk://#diff-f1db7c587c0fc6ae7a362a3b0b9bd308c4b8efa4687f14f248abd72b09ebd58bR20-R27)

**Testing Improvements:**

* Added tests to verify the update command's behavior with both `uv` and `pipx`, as well as its error handling when neither installer is available. (`tests/cli/test_main.py` [[1]](diffhunk://#diff-ca8ba482572f6ca569313a0c0035af634c06a455fe9125cfd0a3e0f124c96a46R4) [[2]](diffhunk://#diff-ca8ba482572f6ca569313a0c0035af634c06a455fe9125cfd0a3e0f124c96a46R85-R137)