### PR TITLE
Improve streaming and HTTP client timeout control

### DIFF
--- a/docs/guides/messages-tasks.mdx
+++ b/docs/guides/messages-tasks.mdx
@@ -5,8 +5,10 @@ description: "Send messages, stream responses, manage tasks, and reuse saved con
 
 # Messages, tasks, and sessions
 
-The CLI is best when you want repeatable A2A operations, automation, or shell-
-friendly workflows.
+Message responses default to readable text for interactive use. Pass
+`--output json` for full protocol responses, or `--output ndjson` before
+streaming commands when you need structured event output for automation or
+agent-driven workflows.
 
 ## Inspect an agent card first
 
@@ -37,8 +39,19 @@ handler message send --url http://localhost:8000 --text "Hello"
 handler message stream --server demo --text "Summarize your capabilities"
 ```
 
+In text mode, streaming prints lightweight `event:` summaries for task state
+changes, tool calls, tool results, data/file parts, and response text before the
+final answer content. That makes it clear when the agent is still working even
+if the model's text arrives in one larger chunk.
+
 The `send` command also accepts `--stream` when you want the same request shape
 but prefer one command form.
+
+Use newline-delimited JSON when you want structured stream events:
+
+```bash
+handler --output ndjson message stream --server demo --text "Summarize your capabilities"
+```
 
 ## Continue a saved conversation
 
@@ -63,10 +76,10 @@ handler message send \
 ## Send custom payloads or headers
 
 For agent-friendly invocation and integration testing, Handler exposes raw JSON
-and repeatable header flags:
+input, structured output, and repeatable header flags:
 
 ```bash
-handler message send \
+handler --output json message send \
   --server demo \
   --json '{"message":{"role":"user","parts":[{"text":"hello"}]}}' \
   --header 'X-Trace-Id: local-test'

--- a/docs/guides/messages-tasks.mdx
+++ b/docs/guides/messages-tasks.mdx
@@ -55,6 +55,25 @@ Use newline-delimited JSON when you want structured stream events:
 handler --output ndjson message stream --server demo --text "Summarize your capabilities"
 ```
 
+If you need to tune networking behavior, Handler exposes global timeout flags
+and matching environment variables. Values are seconds, or `none` to disable a
+specific timeout:
+
+```bash
+handler \
+  --connect-timeout 120 \
+  --read-timeout 120 \
+  --write-timeout 120 \
+  --pool-timeout 120 \
+  --stream-read-timeout none \
+  message stream --server demo --text "Summarize your capabilities"
+```
+
+The same knobs are available as `HANDLER_CONNECT_TIMEOUT`,
+`HANDLER_READ_TIMEOUT`, `HANDLER_WRITE_TIMEOUT`, `HANDLER_POOL_TIMEOUT`, and
+`HANDLER_STREAM_READ_TIMEOUT`. Streaming disables the read timeout by default so
+long-running tasks are not aborted during idle gaps between SSE events.
+
 ## Continue a saved conversation
 
 Handler persists conversation identifiers locally so you can continue later:

--- a/docs/guides/messages-tasks.mdx
+++ b/docs/guides/messages-tasks.mdx
@@ -5,10 +5,11 @@ description: "Send messages, stream responses, manage tasks, and reuse saved con
 
 # Messages, tasks, and sessions
 
-Message responses default to readable text for interactive use. Pass
-`--output json` for full protocol responses, or `--output ndjson` before
+Message responses and errors default to readable text for interactive use.
+Pass `--output json` for full protocol responses, or `--output ndjson` before
 streaming commands when you need structured event output for automation or
-agent-driven workflows.
+agent-driven workflows. Commands without a custom text formatter may still emit
+JSON in the default mode.
 
 ## Inspect an agent card first
 
@@ -71,8 +72,9 @@ handler \
 
 The same knobs are available as `HANDLER_CONNECT_TIMEOUT`,
 `HANDLER_READ_TIMEOUT`, `HANDLER_WRITE_TIMEOUT`, `HANDLER_POOL_TIMEOUT`, and
-`HANDLER_STREAM_READ_TIMEOUT`. Streaming disables the read timeout by default so
-long-running tasks are not aborted during idle gaps between SSE events.
+`HANDLER_STREAM_READ_TIMEOUT`, including from a workspace `.env` file. Streaming
+disables the read timeout by default so long-running tasks are not aborted during
+idle gaps between SSE events.
 
 ## Continue a saved conversation
 

--- a/docs/guides/messages-tasks.mdx
+++ b/docs/guides/messages-tasks.mdx
@@ -42,7 +42,9 @@ handler message stream --server demo --text "Summarize your capabilities"
 In text mode, streaming prints lightweight `event:` summaries for task state
 changes, tool calls, tool results, data/file parts, and response text before the
 final answer content. That makes it clear when the agent is still working even
-if the model's text arrives in one larger chunk.
+if the model's text arrives in one larger chunk. Handler also prints the full
+task ID once when the stream starts so you can resubscribe if the connection is
+interrupted.
 
 The `send` command also accepts `--stream` when you want the same request shape
 but prefer one command form.

--- a/docs/guides/tui.mdx
+++ b/docs/guides/tui.mdx
@@ -79,5 +79,6 @@ By default this binds to `localhost:8001`.
 
 ## When to use the CLI instead
 
-Prefer the CLI when you want scripting, JSON-friendly output, shell history, or
-repeatable task automation. See [Messages, tasks, and sessions](./messages-tasks).
+Prefer the CLI when you want scripting, optional structured output, shell
+history, or repeatable task automation. See
+[Messages, tasks, and sessions](./messages-tasks).

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -33,6 +33,7 @@ from a2a_handler.common.dotenv import load_runtime_dotenv
 from a2a_handler.common.output import OutputFormat
 from a2a_handler.tui import HandlerTUI
 
+from ._helpers import configure_http_timeouts
 from .card import card
 from .mcp import mcp
 from .message import message
@@ -64,6 +65,36 @@ PACKAGE_NAME = "a2a-handler"
     is_flag=True,
     help="Suppress non-error output",
 )
+@click.option(
+    "--connect-timeout",
+    envvar="HANDLER_CONNECT_TIMEOUT",
+    metavar="SECONDS|none",
+    help="HTTP connect timeout in seconds (env: HANDLER_CONNECT_TIMEOUT)",
+)
+@click.option(
+    "--read-timeout",
+    envvar="HANDLER_READ_TIMEOUT",
+    metavar="SECONDS|none",
+    help="HTTP read timeout for non-streaming calls (env: HANDLER_READ_TIMEOUT)",
+)
+@click.option(
+    "--write-timeout",
+    envvar="HANDLER_WRITE_TIMEOUT",
+    metavar="SECONDS|none",
+    help="HTTP write timeout in seconds (env: HANDLER_WRITE_TIMEOUT)",
+)
+@click.option(
+    "--pool-timeout",
+    envvar="HANDLER_POOL_TIMEOUT",
+    metavar="SECONDS|none",
+    help="HTTP connection pool timeout in seconds (env: HANDLER_POOL_TIMEOUT)",
+)
+@click.option(
+    "--stream-read-timeout",
+    envvar="HANDLER_STREAM_READ_TIMEOUT",
+    metavar="SECONDS|none",
+    help="HTTP read timeout for streaming calls; default is none (env: HANDLER_STREAM_READ_TIMEOUT)",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -71,6 +102,11 @@ def cli(
     debug: bool,
     output_format: OutputFormat,
     quiet: bool,
+    connect_timeout: str | None,
+    read_timeout: str | None,
+    write_timeout: str | None,
+    pool_timeout: str | None,
+    stream_read_timeout: str | None,
 ) -> None:
     """Handler - A2A protocol client CLI."""
     load_runtime_dotenv()
@@ -78,6 +114,13 @@ def cli(
     ctx.obj["output_format"] = output_format
     ctx.obj["quiet"] = quiet
     configure_output(output_format=output_format, quiet=quiet)
+    configure_http_timeouts(
+        connect_timeout=connect_timeout,
+        read_timeout=read_timeout,
+        write_timeout=write_timeout,
+        pool_timeout=pool_timeout,
+        stream_read_timeout=stream_read_timeout,
+    )
 
     if debug:
         setup_logging(level="DEBUG")

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -22,6 +22,8 @@ import os
 import shutil
 import subprocess
 import webbrowser
+from collections.abc import Sequence
+from typing import Any
 
 logging.getLogger().setLevel(logging.WARNING)
 
@@ -48,7 +50,31 @@ DOCS_URL = "https://handler.alduncanson.com/"
 PACKAGE_NAME = "a2a-handler"
 
 
-@click.group()
+class RuntimeDotenvGroup(click.Group):
+    """Click group that loads workspace .env before option envvars resolve."""
+
+    def main(
+        self,
+        args: Sequence[str] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        windows_expand_args: bool = True,
+        **extra: Any,
+    ) -> Any:
+        """Load runtime dotenv before Click parses envvar-backed options."""
+        load_runtime_dotenv()
+        return super().main(
+            args=args,
+            prog_name=prog_name,
+            complete_var=complete_var,
+            standalone_mode=standalone_mode,
+            windows_expand_args=windows_expand_args,
+            **extra,
+        )
+
+
+@click.group(cls=RuntimeDotenvGroup)
 @click.version_option(version=__version__, prog_name="handler")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 @click.option("--debug", "-d", is_flag=True, help="Enable debug logging")
@@ -109,7 +135,6 @@ def cli(
     stream_read_timeout: str | None,
 ) -> None:
     """Handler - A2A protocol client CLI."""
-    load_runtime_dotenv()
     ctx.ensure_object(dict)
     ctx.obj["output_format"] = output_format
     ctx.obj["quiet"] = quiet

--- a/src/a2a_handler/cli/__init__.py
+++ b/src/a2a_handler/cli/__init__.py
@@ -54,10 +54,10 @@ PACKAGE_NAME = "a2a-handler"
 @click.option(
     "--output",
     "output_format",
-    type=click.Choice(["json", "ndjson"]),
-    default="json",
+    type=click.Choice(["text", "json", "ndjson"]),
+    default="text",
     show_default=True,
-    help="Output format",
+    help="Output format (use json/ndjson for structured output)",
 )
 @click.option(
     "--quiet",

--- a/src/a2a_handler/cli/_helpers.py
+++ b/src/a2a_handler/cli/_helpers.py
@@ -39,7 +39,7 @@ class AgentSelection:
 
 
 def build_http_client(
-    timeout: int = TIMEOUT,
+    timeout: int | float | httpx.Timeout = TIMEOUT,
     credentials: AuthCredentials | None = None,
 ) -> httpx.AsyncClient:
     """Build an HTTP client with the specified timeout."""
@@ -50,6 +50,26 @@ def build_http_client(
             trust_env=False,
         )
     return httpx.AsyncClient(timeout=timeout, trust_env=False)
+
+
+def build_streaming_http_client(
+    credentials: AuthCredentials | None = None,
+) -> httpx.AsyncClient:
+    """Build an HTTP client for long-lived streaming responses.
+
+    Streaming keeps the usual finite connect/write/pool timeouts but disables
+    the read timeout so an active long-running A2A task is not aborted just
+    because the server has no SSE event ready for a while.
+    """
+    return build_http_client(
+        timeout=httpx.Timeout(
+            connect=TIMEOUT,
+            read=None,
+            write=TIMEOUT,
+            pool=TIMEOUT,
+        ),
+        credentials=credentials,
+    )
 
 
 def handle_client_error(e: Exception, agent_url: str, output: Output | None) -> None:

--- a/src/a2a_handler/cli/_helpers.py
+++ b/src/a2a_handler/cli/_helpers.py
@@ -27,6 +27,13 @@ from a2a_handler.servers import (
 )
 
 TIMEOUT = 120
+_TIMEOUT_NONE_VALUES = {"none", "null", "off", "disabled"}
+
+_connect_timeout: float | None = float(TIMEOUT)
+_read_timeout: float | None = float(TIMEOUT)
+_write_timeout: float | None = float(TIMEOUT)
+_pool_timeout: float | None = float(TIMEOUT)
+_stream_read_timeout: float | None = None
 log = get_logger(__name__)
 
 
@@ -39,17 +46,18 @@ class AgentSelection:
 
 
 def build_http_client(
-    timeout: int | float | httpx.Timeout = TIMEOUT,
+    timeout: int | float | httpx.Timeout | None = None,
     credentials: AuthCredentials | None = None,
 ) -> httpx.AsyncClient:
     """Build an HTTP client with the specified timeout."""
+    effective_timeout = timeout if timeout is not None else _standard_timeout()
     if credentials and credentials.auth_type == AuthType.MTLS:
         return httpx.AsyncClient(
-            timeout=timeout,
+            timeout=effective_timeout,
             verify=credentials.build_ssl_context(),
             trust_env=False,
         )
-    return httpx.AsyncClient(timeout=timeout, trust_env=False)
+    return httpx.AsyncClient(timeout=effective_timeout, trust_env=False)
 
 
 def build_streaming_http_client(
@@ -63,13 +71,84 @@ def build_streaming_http_client(
     """
     return build_http_client(
         timeout=httpx.Timeout(
-            connect=TIMEOUT,
-            read=None,
-            write=TIMEOUT,
-            pool=TIMEOUT,
+            connect=_connect_timeout,
+            read=_stream_read_timeout,
+            write=_write_timeout,
+            pool=_pool_timeout,
         ),
         credentials=credentials,
     )
+
+
+def configure_http_timeouts(
+    *,
+    connect_timeout: str | int | float | None = None,
+    read_timeout: str | int | float | None = None,
+    write_timeout: str | int | float | None = None,
+    pool_timeout: str | int | float | None = None,
+    stream_read_timeout: str | int | float | None = None,
+) -> None:
+    """Configure default CLI HTTP timeouts.
+
+    Passing no values resets the defaults. String values may be seconds or
+    ``none`` to disable that timeout.
+    """
+    global _connect_timeout, _read_timeout, _write_timeout, _pool_timeout
+    global _stream_read_timeout
+
+    _connect_timeout = _parse_timeout_option(
+        connect_timeout, "connect-timeout", float(TIMEOUT)
+    )
+    _read_timeout = _parse_timeout_option(read_timeout, "read-timeout", float(TIMEOUT))
+    _write_timeout = _parse_timeout_option(
+        write_timeout, "write-timeout", float(TIMEOUT)
+    )
+    _pool_timeout = _parse_timeout_option(pool_timeout, "pool-timeout", float(TIMEOUT))
+    _stream_read_timeout = _parse_timeout_option(
+        stream_read_timeout, "stream-read-timeout", None
+    )
+
+
+def _standard_timeout() -> httpx.Timeout:
+    """Return the configured timeout for regular request/response calls."""
+    return httpx.Timeout(
+        connect=_connect_timeout,
+        read=_read_timeout,
+        write=_write_timeout,
+        pool=_pool_timeout,
+    )
+
+
+def _parse_timeout_option(
+    value: str | int | float | None,
+    field_name: str,
+    default: float | None,
+) -> float | None:
+    """Parse a CLI/env timeout value."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized:
+            return default
+        if normalized in _TIMEOUT_NONE_VALUES:
+            return None
+        try:
+            parsed = float(normalized)
+        except ValueError as exc:
+            raise click.BadParameter(
+                "must be a number of seconds or 'none'",
+                param_hint=f"--{field_name}",
+            ) from exc
+    else:
+        parsed = float(value)
+
+    if parsed < 0:
+        raise click.BadParameter(
+            "must be greater than or equal to 0",
+            param_hint=f"--{field_name}",
+        )
+    return parsed
 
 
 def handle_client_error(e: Exception, agent_url: str, output: Output | None) -> None:

--- a/src/a2a_handler/cli/card.py
+++ b/src/a2a_handler/cli/card.py
@@ -11,8 +11,8 @@ from a2a_handler.common.input_validation import InputValidationError, validate_a
 from a2a_handler.service import A2AService
 from a2a_handler.validation import (
     ValidationResult,
+    ValidationSource,
     validate_agent_card_from_file,
-    validate_agent_card_from_url,
 )
 
 from ._helpers import (
@@ -155,7 +155,14 @@ def card_validate(
 
     async def do_validate() -> None:
         async with build_http_client(credentials=credentials) as http_client:
-            result = await validate_agent_card_from_url(resolved_url, http_client)
+            service = A2AService(http_client, resolved_url, credentials=credentials)
+            agent_card = await service.get_card()
+            result = ValidationResult(
+                valid=True,
+                source=resolved_url,
+                source_type=ValidationSource.URL,
+                agent_card=agent_card,
+            )
 
         _format_validation_result(result, output)
 

--- a/src/a2a_handler/cli/message.py
+++ b/src/a2a_handler/cli/message.py
@@ -544,7 +544,7 @@ def _stream_text_delta(emitted_text: str, event_text: str) -> str:
     """Return only the not-yet-emitted portion of a stream text event."""
     if not emitted_text:
         return event_text
-    if event_text == emitted_text or event_text in emitted_text:
+    if event_text == emitted_text:
         return ""
     if event_text.startswith(emitted_text):
         return event_text[len(emitted_text) :]

--- a/src/a2a_handler/cli/message.py
+++ b/src/a2a_handler/cli/message.py
@@ -37,6 +37,7 @@ from a2a_handler.session import get_session, update_session
 
 from ._helpers import (
     build_http_client,
+    build_streaming_http_client,
     handle_client_error,
     handle_validation_error,
     resolve_agent_selection,
@@ -232,7 +233,10 @@ def message_send(
 
     async def do_send() -> None:
         try:
-            async with build_http_client(credentials=credentials) as http_client:
+            client_factory = (
+                build_streaming_http_client if stream else build_http_client
+            )
+            async with client_factory(credentials=credentials) as http_client:
                 service = A2AService(
                     http_client,
                     resolved_url,
@@ -343,6 +347,7 @@ async def _stream_message(
     text_line_open = False
     separated_text_from_events = False
     last_output_was_text = False
+    emitted_full_task_id: str | None = None
 
     async for event in service.stream(text, context_id, task_id):
         last_context_id = event.context_id or last_context_id
@@ -355,6 +360,10 @@ async def _stream_message(
         if output.output_format == "ndjson":
             output.json(_stream_event_dump(event))
         elif output.output_format == "text":
+            if event.task_id and emitted_full_task_id is None:
+                output.text(f"task id: {event.task_id}", flush=True)
+                emitted_full_task_id = event.task_id
+
             for summary in _format_stream_event_summaries(event):
                 if summary in emitted_summaries:
                     continue

--- a/src/a2a_handler/cli/message.py
+++ b/src/a2a_handler/cli/message.py
@@ -191,17 +191,6 @@ def message_send(
                 handle_validation_error(error, output)
                 raise click.Abort() from error
             context_id = session.context_id
-            if not task_id and session.task_id:
-                try:
-                    validate_resource_id(session.task_id, "task_id")
-                except InputValidationError as error:
-                    log.warning(
-                        "Ignoring saved task_id for %s: %s",
-                        resolved_url,
-                        error.message,
-                    )
-                else:
-                    task_id = session.task_id
             log.info("Using saved context: %s", context_id)
 
     custom_headers: dict[str, str] | None = None

--- a/src/a2a_handler/cli/message.py
+++ b/src/a2a_handler/cli/message.py
@@ -1,11 +1,13 @@
 """Message commands for sending messages to A2A agents."""
 
 import asyncio
+import json
 from dataclasses import replace
 from typing import Any
 from typing import Optional
 
 import click
+from a2a.types import DataPart, FilePart, Message, Part, Role, TextPart
 
 from a2a_handler.auth import (
     AuthCredentials,
@@ -25,8 +27,10 @@ from a2a_handler.common.input_validation import (
 from a2a_handler.service import (
     A2AService,
     A2AResponse,
+    StreamEvent,
     protocol_dump,
     response_context_id,
+    response_state,
     response_task_id,
 )
 from a2a_handler.session import get_session, update_session
@@ -334,6 +338,11 @@ async def _stream_message(
     last_context_id: str | None = None
     last_task_id: str | None = None
     last_response: A2AResponse | None = None
+    emitted_text = ""
+    emitted_summaries: set[str] = set()
+    text_line_open = False
+    separated_text_from_events = False
+    last_output_was_text = False
 
     async for event in service.stream(text, context_id, task_id):
         last_context_id = event.context_id or last_context_id
@@ -343,14 +352,278 @@ async def _stream_message(
         elif event.message:
             last_response = event.message
 
+        if output.output_format == "ndjson":
+            output.json(_stream_event_dump(event))
+        elif output.output_format == "text":
+            for summary in _format_stream_event_summaries(event):
+                if summary in emitted_summaries:
+                    continue
+                if text_line_open:
+                    output.text(flush=True)
+                    text_line_open = False
+                if last_output_was_text:
+                    output.text(flush=True)
+                output.text(summary, flush=True)
+                emitted_summaries.add(summary)
+                last_output_was_text = False
+
+            event_text = _format_stream_event_text(event)
+            if event_text:
+                text_to_emit = _stream_text_delta(emitted_text, event_text)
+                if text_to_emit:
+                    if emitted_summaries and not separated_text_from_events:
+                        output.text(flush=True)
+                        separated_text_from_events = True
+                    output.text(text_to_emit, end="", flush=True)
+                    emitted_text += text_to_emit
+                    text_line_open = not text_to_emit.endswith("\n")
+                    last_output_was_text = True
+
     update_session(agent_url, last_context_id, last_task_id)
 
     if last_response:
-        output.json(protocol_dump(last_response))
+        if output.output_format == "json":
+            output.json(protocol_dump(last_response))
+        elif output.output_format == "text":
+            if emitted_text:
+                if text_line_open:
+                    output.text()
+            else:
+                output.text(_format_response_text(last_response))
     else:
         output.error(code="no_response", message="No response received from stream")
 
 
 def _format_response(response: A2AResponse, output: Output) -> None:
     """Format and display an A2A response."""
-    output.json(protocol_dump(response))
+    if output.is_structured:
+        output.json(protocol_dump(response))
+    else:
+        output.text(_format_response_text(response))
+
+
+def _format_response_text(response: A2AResponse) -> str:
+    """Format an A2A response as human-readable text."""
+    text = _format_response_parts(response)
+    if text:
+        return text
+
+    lines: list[str] = []
+    state = response_state(response)
+    if state:
+        lines.append(f"State: {state.value}")
+    context_id = response_context_id(response)
+    if context_id:
+        lines.append(f"Context ID: {context_id}")
+    task_id = response_task_id(response)
+    if task_id:
+        lines.append(f"Task ID: {task_id}")
+    if not lines:
+        lines.append("No text response received.")
+    return "\n".join(lines)
+
+
+def _format_response_parts(response: A2AResponse) -> str:
+    """Format response parts for human-readable CLI output."""
+    if isinstance(response, Message):
+        return _format_message_parts(response)
+
+    formatted_parts: list[str] = []
+    if response.artifacts:
+        for artifact in response.artifacts:
+            formatted = _format_parts(artifact.parts)
+            if formatted:
+                formatted_parts.append(formatted)
+
+    if not formatted_parts and response.history:
+        for message in response.history:
+            if message.role == Role.agent:
+                formatted = _format_message_parts(message)
+                if formatted:
+                    formatted_parts.append(formatted)
+
+    return "\n\n".join(formatted_parts)
+
+
+def _format_stream_event_text(event: StreamEvent) -> str:
+    """Format a streaming event for human-readable text output."""
+    if event.message:
+        return _format_message_parts(event.message)
+
+    if event.status and event.status.status and event.status.status.message:
+        return _format_message_parts(event.status.status.message)
+
+    if event.artifact and event.artifact.artifact:
+        return _format_parts(event.artifact.artifact.parts)
+
+    if event.event_type == "task" and event.task:
+        return _format_response_parts(event.task)
+
+    return event.text
+
+
+def _format_stream_event_summaries(event: StreamEvent) -> list[str]:
+    """Return lightweight event summaries for human-readable stream output."""
+    summaries: list[str] = []
+
+    if event.state:
+        summaries.append(
+            _format_event_summary("task", event.state.value, event.task_id)
+        )
+
+    parts = _stream_event_parts(event)
+    for part in parts:
+        summaries.extend(_format_part_event_summaries(part, event.task_id))
+
+    if event.event_type == "artifact" and not summaries:
+        summaries.append(_format_event_summary("artifact", "updated", event.task_id))
+
+    return summaries
+
+
+def _stream_event_parts(event: StreamEvent) -> list[Part]:
+    """Return the parts carried by a stream event, if any."""
+    if event.message and event.message.role == Role.agent:
+        return event.message.parts or []
+    if event.status and event.status.status and event.status.status.message:
+        message = event.status.status.message
+        if message.role == Role.agent:
+            return message.parts or []
+    if event.artifact and event.artifact.artifact:
+        return event.artifact.artifact.parts or []
+    return []
+
+
+def _format_part_event_summaries(part: Part, task_id: str | None) -> list[str]:
+    """Summarize a stream part without rendering its full content."""
+    root = part.root
+    if isinstance(root, TextPart):
+        return [_format_event_summary("message", "text", task_id)]
+    if isinstance(root, DataPart):
+        if _is_tool_call_data(root.data):
+            return [
+                _format_event_summary(
+                    "tool call", str(root.data.get("name", "unknown")), task_id
+                )
+            ]
+        if _is_tool_response_data(root.data):
+            return [
+                _format_event_summary(
+                    "tool result", str(root.data.get("name", "unknown")), task_id
+                )
+            ]
+        return [_format_event_summary("message", "data", task_id)]
+    if isinstance(root, FilePart):
+        return [_format_event_summary("message", "file", task_id)]
+    return [_format_event_summary("message", getattr(root, "kind", "part"), task_id)]
+
+
+def _format_event_summary(kind: str, detail: str, task_id: str | None) -> str:
+    """Format one human-readable stream event summary."""
+    task_suffix = f" ({_short_id(task_id)})" if task_id else ""
+    return f"event: {kind} {detail}{task_suffix}"
+
+
+def _short_id(value: str | None) -> str:
+    """Return a compact identifier for stream summaries."""
+    if not value:
+        return ""
+    return value[:8]
+
+
+def _stream_text_delta(emitted_text: str, event_text: str) -> str:
+    """Return only the not-yet-emitted portion of a stream text event."""
+    if not emitted_text:
+        return event_text
+    if event_text == emitted_text or event_text in emitted_text:
+        return ""
+    if event_text.startswith(emitted_text):
+        return event_text[len(emitted_text) :]
+    return event_text
+
+
+def _format_message_parts(message: Message) -> str:
+    """Format a protocol message's parts, skipping echoed user messages."""
+    if message.role != Role.agent:
+        return ""
+    return _format_parts(message.parts)
+
+
+def _format_parts(parts: list[Part] | None) -> str:
+    """Format A2A message/artifact parts for human-readable CLI output."""
+    if not parts:
+        return ""
+
+    formatted_parts: list[str] = []
+    for part in parts:
+        formatted = _format_part(part)
+        if formatted:
+            formatted_parts.append(formatted)
+    return "\n\n".join(formatted_parts)
+
+
+def _format_part(part: Part) -> str:
+    """Format a single A2A part for human-readable CLI output."""
+    root = part.root
+    if isinstance(root, TextPart):
+        return root.text
+    if isinstance(root, DataPart):
+        return _format_data_part(root)
+    if isinstance(root, FilePart):
+        return _format_file_part(root)
+
+    return "```json\n" + json.dumps(part.model_dump(mode="json"), indent=2) + "\n```"
+
+
+def _format_data_part(part: DataPart) -> str:
+    """Format structured data parts while hiding internal tool chatter."""
+    data = part.data
+    if _is_tool_call_data(data) or _is_tool_response_data(data):
+        return ""
+    return "```json\n" + json.dumps(data, indent=2, default=str) + "\n```"
+
+
+def _is_tool_call_data(data: dict[str, Any]) -> bool:
+    """Return whether a data part looks like an internal tool call."""
+    return {"id", "name", "args"}.issubset(data)
+
+
+def _is_tool_response_data(data: dict[str, Any]) -> bool:
+    """Return whether a data part looks like an internal tool response."""
+    return {"id", "name", "response"}.issubset(data)
+
+
+def _format_file_part(part: FilePart) -> str:
+    """Format file parts without dumping inline bytes into the terminal."""
+    file_part = part.file
+    name = getattr(file_part, "name", None) or "unnamed file"
+    mime_type = getattr(file_part, "mime_type", None)
+    uri = getattr(file_part, "uri", None)
+    inline_bytes = getattr(file_part, "bytes", None)
+
+    details = [name]
+    if mime_type:
+        details.append(mime_type)
+    if uri:
+        details.append(uri)
+    elif inline_bytes:
+        details.append(f"inline bytes, {len(inline_bytes)} base64 chars")
+    return "[file: " + ", ".join(details) + "]"
+
+
+def _stream_event_dump(event: StreamEvent) -> dict[str, object]:
+    """Serialize a streaming event for NDJSON output."""
+    data: dict[str, object] = {"type": event.event_type}
+    if event.context_id:
+        data["contextId"] = event.context_id
+    if event.task_id:
+        data["taskId"] = event.task_id
+    if event.state:
+        data["state"] = event.state.value
+    if event.text:
+        data["text"] = event.text
+    if event.message:
+        data["message"] = protocol_dump(event.message)
+    if event.task:
+        data["task"] = protocol_dump(event.task)
+    return data

--- a/src/a2a_handler/cli/schema.py
+++ b/src/a2a_handler/cli/schema.py
@@ -85,7 +85,6 @@ def schema(ctx: click.Context) -> None:
 
     \b
     Examples:
-      $ handler schema
       $ handler --output json schema
     """
     root = ctx.find_root().command
@@ -102,9 +101,9 @@ def describe(ctx: click.Context, command_path: tuple[str, ...]) -> None:
 
     \b
     Examples:
-      $ handler describe message send
-      $ handler describe task get
-      $ handler describe server add
+      $ handler --output json describe message send
+      $ handler --output json describe task get
+      $ handler --output json describe server add
     """
     root = ctx.find_root().command
     assert isinstance(root, click.Group)

--- a/src/a2a_handler/cli/task.py
+++ b/src/a2a_handler/cli/task.py
@@ -25,6 +25,7 @@ from a2a_handler.service import (
 
 from ._helpers import (
     build_http_client,
+    build_streaming_http_client,
     handle_client_error,
     handle_validation_error,
     resolve_agent_selection,
@@ -217,7 +218,9 @@ def task_resubscribe(
 
     async def do_resubscribe() -> None:
         try:
-            async with build_http_client(credentials=credentials) as http_client:
+            async with build_streaming_http_client(
+                credentials=credentials
+            ) as http_client:
                 service = A2AService(http_client, resolved_url, credentials=credentials)
 
                 last_task: Task | None = None

--- a/src/a2a_handler/common/output.py
+++ b/src/a2a_handler/common/output.py
@@ -1,7 +1,8 @@
 """Output system for CLI.
 
-All command output is structured JSON or NDJSON.  Errors are emitted to
-stderr as JSON.
+Commands default to text mode when they provide a human-readable formatter.
+Structured JSON and NDJSON are available for automation through the global
+``--output`` option.
 """
 
 from __future__ import annotations
@@ -10,13 +11,13 @@ import json as json_module
 import sys
 from typing import Any, Literal
 
-OutputFormat = Literal["json", "ndjson"]
+OutputFormat = Literal["text", "json", "ndjson"]
 
-_DEFAULT_OUTPUT_FORMAT: OutputFormat = "json"
+_DEFAULT_OUTPUT_FORMAT: OutputFormat = "text"
 _DEFAULT_QUIET = False
 
 
-def configure_output(output_format: OutputFormat = "json", quiet: bool = False) -> None:
+def configure_output(output_format: OutputFormat = "text", quiet: bool = False) -> None:
     """Configure default output behavior for CLI commands."""
     global _DEFAULT_OUTPUT_FORMAT, _DEFAULT_QUIET
     _DEFAULT_OUTPUT_FORMAT = output_format
@@ -24,7 +25,7 @@ def configure_output(output_format: OutputFormat = "json", quiet: bool = False) 
 
 
 class Output:
-    """Emits structured JSON/NDJSON to stdout, errors to stderr."""
+    """Emit CLI output in text, JSON, or NDJSON format."""
 
     def __init__(
         self,
@@ -34,8 +35,24 @@ class Output:
         self._output_format: OutputFormat = output_format or _DEFAULT_OUTPUT_FORMAT
         self._quiet = _DEFAULT_QUIET if quiet is None else quiet
 
+    @property
+    def output_format(self) -> OutputFormat:
+        """Return the active output format."""
+        return self._output_format
+
+    @property
+    def is_structured(self) -> bool:
+        """Whether output should be structured for machine consumers."""
+        return self._output_format in {"json", "ndjson"}
+
+    def text(self, text: str = "", *, end: str = "\n", flush: bool = False) -> None:
+        """Emit human-readable text to stdout."""
+        if self._quiet:
+            return
+        print(text, end=end, flush=flush)
+
     def json(self, data: Any) -> None:
-        """Emit a domain object to stdout."""
+        """Emit a domain object to stdout as JSON/NDJSON."""
         if self._quiet:
             return
         if self._output_format == "ndjson":
@@ -62,5 +79,35 @@ class Output:
             payload["suggestion"] = suggestion
         if self._output_format == "ndjson":
             print(json_module.dumps(payload, default=str), file=sys.stderr)
-        else:
+        elif self._output_format == "json":
             print(json_module.dumps(payload, indent=2, default=str), file=sys.stderr)
+        else:
+            print(f"Error: {message}", file=sys.stderr)
+            if details is not None:
+                print(f"Details: {_format_text_data(details)}", file=sys.stderr)
+            if suggestion:
+                print(f"Suggestion: {suggestion}", file=sys.stderr)
+
+
+def _format_text_data(data: Any, indent: int = 0) -> str:
+    """Format arbitrary JSON-compatible data as readable plain text."""
+    prefix = " " * indent
+    if isinstance(data, dict):
+        lines: list[str] = []
+        for key, value in data.items():
+            if isinstance(value, (dict, list)):
+                lines.append(f"{prefix}{key}:")
+                lines.append(_format_text_data(value, indent + 2))
+            else:
+                lines.append(f"{prefix}{key}: {value}")
+        return "\n".join(lines)
+    if isinstance(data, list):
+        lines = []
+        for item in data:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{prefix}-")
+                lines.append(_format_text_data(item, indent + 2))
+            else:
+                lines.append(f"{prefix}- {item}")
+        return "\n".join(lines)
+    return f"{prefix}{data}"

--- a/src/a2a_handler/server/agent.py
+++ b/src/a2a_handler/server/agent.py
@@ -86,6 +86,8 @@ Handler is an A2A protocol client published on PyPI as `a2a-handler`. It provide
 
 You have access to Handler's hosted documentation through an MCP server, Handler's locally installed source code through source search tools, and A2A protocol documentation through local documentation search/fetch tools backed by the official A2A protocol site's llms text files. Use these tools when answering Handler-specific or A2A-specific questions about commands, configuration, workflows, authentication, MCP, local servers, tasks, messages, artifacts, streaming, implementation details, or troubleshooting. Prefer current documentation and local source over memory, and cite the relevant page, source file, or command when helpful.
 
+Only call tools that are actually registered for you. For Handler documentation, use `handler_docs_search_handler` or `handler_docs_query_docs_filesystem_handler`. For A2A protocol documentation, use `search_a2a_protocol_docs` for targeted lookup and `fetch_a2a_protocol_docs` only when you need a broader reference. For Handler source code, use `search_handler_source`. Do not call `google:search`, web search, browser, or any other unlisted tool.
+
 Handler's architecture consists of:
 1. **TUI** - An interactive terminal interface (Textual-based) for managing agent connections, sending messages, and viewing streaming responses
 2. **CLI** - A rich-click powered command-line interface for scripting and automation

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -500,7 +500,9 @@ class A2AService:
                 if isinstance(task_update, TaskStatusUpdateEvent):
                     status_message_text = ""
                     if task_update.status and task_update.status.message:
-                        status_message_text = str(task_update.status.message)
+                        status_message_text = extract_text_from_message_parts(
+                            task_update.status.message.parts
+                        )
                     yield StreamEvent(
                         event_type="status",
                         task=received_task,

--- a/tests/cli/test_card.py
+++ b/tests/cli/test_card.py
@@ -223,28 +223,58 @@ class TestCardValidate:
 
     def test_validate_url(self, runner):
         """Test validating a card from URL."""
-        mock_result = ValidationResult(
-            valid=True,
-            source="http://localhost:8000/.well-known/agent.json",
-            source_type=ValidationSource.URL,
-            agent_card=_make_agent_card(),
-        )
+        mock_card = _make_agent_card()
 
         with (
             patch("a2a_handler.cli.card.build_http_client") as mock_client,
-            patch("a2a_handler.cli.card.validate_agent_card_from_url") as mock_validate,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
         ):
             mock_http = AsyncMock()
             mock_http.__aenter__.return_value = mock_http
             mock_http.__aexit__.return_value = None
             mock_client.return_value = mock_http
 
-            mock_validate.return_value = mock_result
+            mock_service = AsyncMock()
+            mock_service.get_card.return_value = mock_card
+            mock_service_cls.return_value = mock_service
 
             result = runner.invoke(card, ["validate", "--url", "http://localhost:8000"])
 
             assert result.exit_code == 0
             assert '"valid": true' in result.output
+
+    def test_validate_url_uses_resolved_credentials(self, runner):
+        """Test card validate passes resolved credentials through service."""
+        mock_card = _make_agent_card()
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_card.return_value = mock_card
+            mock_service_cls.return_value = mock_service
+
+            with mock_patch.dict(os.environ, {"TEST_BEARER_TOKEN": "test-token"}):
+                result = runner.invoke(
+                    card,
+                    [
+                        "validate",
+                        "--url",
+                        "http://localhost:8000",
+                        "--bearer-env",
+                        "TEST_BEARER_TOKEN",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service_cls.call_args
+        assert call_kwargs[1]["credentials"] is not None
 
     def test_validate_rejects_invalid_url(self, runner):
         """Test validating malformed URL source fails with validation envelope."""

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -16,11 +16,12 @@ from a2a_handler.auth import AuthType
 from a2a_handler.cli._helpers import (
     AgentSelection,
     build_http_client,
+    build_streaming_http_client,
     handle_client_error,
+    TIMEOUT,
     resolve_agent_selection,
     resolve_selection_credentials,
     resolve_agent_target,
-    TIMEOUT,
 )
 from a2a_handler.common import Output
 from a2a_handler.servers import (
@@ -51,6 +52,14 @@ class TestBuildHttpClient:
         client = build_http_client(timeout=60)
         assert client.timeout.connect == 60
         assert client.timeout.read == 60
+
+    def test_streaming_timeout_disables_read_timeout(self):
+        """Test streaming clients keep finite setup timeouts but no read timeout."""
+        client = build_streaming_http_client()
+        assert client.timeout.connect == TIMEOUT
+        assert client.timeout.read is None
+        assert client.timeout.write == TIMEOUT
+        assert client.timeout.pool == TIMEOUT
 
 
 class TestHandleClientError:

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -17,6 +17,7 @@ from a2a_handler.cli._helpers import (
     AgentSelection,
     build_http_client,
     build_streaming_http_client,
+    configure_http_timeouts,
     handle_client_error,
     TIMEOUT,
     resolve_agent_selection,
@@ -60,6 +61,43 @@ class TestBuildHttpClient:
         assert client.timeout.read is None
         assert client.timeout.write == TIMEOUT
         assert client.timeout.pool == TIMEOUT
+
+    def test_configured_timeouts_apply_to_standard_and_streaming_clients(self):
+        """Test configured timeout knobs are used by HTTP clients."""
+        configure_http_timeouts(
+            connect_timeout="5",
+            read_timeout="6",
+            write_timeout="7",
+            pool_timeout="8",
+            stream_read_timeout="9",
+        )
+
+        standard_client = build_http_client()
+        assert standard_client.timeout.connect == 5
+        assert standard_client.timeout.read == 6
+        assert standard_client.timeout.write == 7
+        assert standard_client.timeout.pool == 8
+
+        streaming_client = build_streaming_http_client()
+        assert streaming_client.timeout.connect == 5
+        assert streaming_client.timeout.read == 9
+        assert streaming_client.timeout.write == 7
+        assert streaming_client.timeout.pool == 8
+
+    def test_timeout_none_value_disables_timeout(self):
+        """Test 'none' disables a configured timeout."""
+        configure_http_timeouts(read_timeout="none", stream_read_timeout="30")
+
+        standard_client = build_http_client()
+        assert standard_client.timeout.read is None
+
+        streaming_client = build_streaming_http_client()
+        assert streaming_client.timeout.read == 30
+
+    def test_invalid_timeout_value_raises_click_error(self):
+        """Test invalid timeout values are rejected."""
+        with pytest.raises(click.BadParameter):
+            configure_http_timeouts(connect_timeout="not-a-number")
 
 
 class TestHandleClientError:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -73,6 +73,14 @@ def test_version_output(runner: CliRunner) -> None:
     assert '"version"' in result.output
 
 
+def test_version_json_output(runner: CliRunner) -> None:
+    """Version command emits JSON when requested."""
+    result = runner.invoke(cli, ["--output", "json", "version"])
+
+    assert result.exit_code == 0
+    assert '"version"' in result.output
+
+
 def test_docs_opens_deployed_documentation(runner: CliRunner) -> None:
     """Docs command opens the hosted documentation URL."""
     with patch("a2a_handler.cli.webbrowser.open", return_value=True) as mock_open:
@@ -138,4 +146,4 @@ def test_update_errors_when_no_supported_installer_is_available(
         result = runner.invoke(cli, ["update"])
 
     assert result.exit_code == 1
-    assert '"code": "installer_not_found"' in result.output
+    assert "Could not find uv or pipx" in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -144,6 +144,41 @@ def test_timeout_env_vars_configure_http_clients(runner: CliRunner) -> None:
     assert build_streaming_http_client().timeout.read == 24
 
 
+def test_timeout_env_vars_load_from_workspace_dotenv_before_click_parses(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Timeout envvars in .env are loaded before Click resolves options."""
+    workspace = tmp_path / "repo"
+    nested_dir = workspace / "src"
+    nested_dir.mkdir(parents=True)
+    (workspace / ".env").write_text(
+        "HANDLER_CONNECT_TIMEOUT=30\n"
+        "HANDLER_READ_TIMEOUT=31\n"
+        "HANDLER_WRITE_TIMEOUT=32\n"
+        "HANDLER_POOL_TIMEOUT=33\n"
+        "HANDLER_STREAM_READ_TIMEOUT=34\n"
+    )
+    monkeypatch.chdir(nested_dir)
+    for name in (
+        "HANDLER_CONNECT_TIMEOUT",
+        "HANDLER_READ_TIMEOUT",
+        "HANDLER_WRITE_TIMEOUT",
+        "HANDLER_POOL_TIMEOUT",
+        "HANDLER_STREAM_READ_TIMEOUT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    result = runner.invoke(cli, ["version"])
+
+    assert result.exit_code == 0
+    standard_client = build_http_client()
+    assert standard_client.timeout.connect == 30
+    assert standard_client.timeout.read == 31
+    assert standard_client.timeout.write == 32
+    assert standard_client.timeout.pool == 33
+    assert build_streaming_http_client().timeout.read == 34
+
+
 def test_update_uses_uv_when_available(runner: CliRunner) -> None:
     """Update command uses uv tool upgrade when uv is available."""
     completed = subprocess.CompletedProcess(

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,7 @@ from unittest.mock import patch as mock_patch
 import pytest
 from click.testing import CliRunner
 
+from a2a_handler.cli._helpers import build_http_client, build_streaming_http_client
 from a2a_handler.cli import cli
 
 
@@ -90,6 +91,57 @@ def test_docs_opens_deployed_documentation(runner: CliRunner) -> None:
     mock_open.assert_called_once_with("https://handler.alduncanson.com/")
     assert '"url": "https://handler.alduncanson.com/"' in result.output
     assert '"opened": true' in result.output
+
+
+def test_timeout_flags_configure_http_clients(runner: CliRunner) -> None:
+    """Global timeout flags configure standard and streaming HTTP clients."""
+    result = runner.invoke(
+        cli,
+        [
+            "--connect-timeout",
+            "10",
+            "--read-timeout",
+            "11",
+            "--write-timeout",
+            "12",
+            "--pool-timeout",
+            "13",
+            "--stream-read-timeout",
+            "none",
+            "version",
+        ],
+    )
+
+    assert result.exit_code == 0
+    standard_client = build_http_client()
+    assert standard_client.timeout.connect == 10
+    assert standard_client.timeout.read == 11
+    assert standard_client.timeout.write == 12
+    assert standard_client.timeout.pool == 13
+    assert build_streaming_http_client().timeout.read is None
+
+
+def test_timeout_env_vars_configure_http_clients(runner: CliRunner) -> None:
+    """Timeout environment variables configure HTTP clients."""
+    result = runner.invoke(
+        cli,
+        ["version"],
+        env={
+            "HANDLER_CONNECT_TIMEOUT": "20",
+            "HANDLER_READ_TIMEOUT": "21",
+            "HANDLER_WRITE_TIMEOUT": "22",
+            "HANDLER_POOL_TIMEOUT": "23",
+            "HANDLER_STREAM_READ_TIMEOUT": "24",
+        },
+    )
+
+    assert result.exit_code == 0
+    standard_client = build_http_client()
+    assert standard_client.timeout.connect == 20
+    assert standard_client.timeout.read == 21
+    assert standard_client.timeout.write == 22
+    assert standard_client.timeout.pool == 23
+    assert build_streaming_http_client().timeout.read == 24
 
 
 def test_update_uses_uv_when_available(runner: CliRunner) -> None:

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -125,7 +125,7 @@ class TestMessageSend:
             mock_service.send.assert_called_once_with("Hello", "ctx-456", None)
 
     def test_message_send_with_continue_flag(self, runner):
-        """Test message send with --continue flag uses session."""
+        """Test --continue resumes the saved context without a terminal task."""
         from a2a_handler.session import AgentSession
 
         mock_session = AgentSession(
@@ -163,9 +163,7 @@ class TestMessageSend:
             )
 
             assert result.exit_code == 0
-            mock_service.send.assert_called_once_with(
-                "Hello", "saved-ctx", "saved-task"
-            )
+            mock_service.send.assert_called_once_with("Hello", "saved-ctx", None)
 
     def test_message_send_with_bearer_auth(self, runner):
         """Test message send with bearer token."""

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -6,7 +6,19 @@ from unittest.mock import patch as mock_patch
 
 import pytest
 from click.testing import CliRunner
-from a2a.types import Message, Part, Role, Task, TaskState, TaskStatus, TextPart
+from a2a.types import (
+    DataPart,
+    FilePart,
+    FileWithBytes,
+    Message,
+    Part,
+    Role,
+    Task,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
 
 from a2a_handler.cli.message import message, _format_response, _stream_message
 from a2a_handler.common import Output
@@ -382,10 +394,40 @@ class TestFormatResponse:
         """Test formatting a result without text."""
         mock_task = _make_task(TaskState.completed)
         output = MagicMock(spec=Output)
+        output.is_structured = True
 
         _format_response(mock_task, output)
 
         output.json.assert_called_once()
+
+    def test_format_data_and_file_parts_as_readable_text(self):
+        """Test text mode formats non-text parts without raw protocol reprs."""
+        mock_message = Message(
+            message_id="msg-1",
+            role=Role.agent,
+            parts=[
+                Part(root=TextPart(text="Here is data:")),
+                Part(root=DataPart(data={"answer": 42})),
+                Part(
+                    root=FilePart(
+                        file=FileWithBytes(
+                            bytes="YWJj",
+                            name="example.txt",
+                            mime_type="text/plain",
+                        )
+                    )
+                ),
+            ],
+        )
+        output = MagicMock(spec=Output)
+        output.is_structured = False
+
+        _format_response(mock_message, output)
+
+        text = output.text.call_args.args[0]
+        assert "Here is data:" in text
+        assert '"answer": 42' in text
+        assert "[file: example.txt, text/plain, inline bytes" in text
 
 
 class TestStreamMessage:
@@ -393,7 +435,7 @@ class TestStreamMessage:
 
     @pytest.mark.asyncio
     async def test_stream_message_collects_response(self):
-        """Test _stream_message emits JSON for last response."""
+        """Test _stream_message emits JSON for last response in JSON mode."""
         mock_task = _make_task(TaskState.completed)
 
         async def mock_stream(*args, **kwargs):
@@ -412,6 +454,7 @@ class TestStreamMessage:
         mock_service.stream = mock_stream
 
         output = MagicMock(spec=Output)
+        output.output_format = "json"
 
         with patch("a2a_handler.cli.message.update_session"):
             await _stream_message(
@@ -424,6 +467,129 @@ class TestStreamMessage:
             )
 
         output.json.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_message_prints_text_chunks(self):
+        """Test _stream_message streams text chunks in default text mode."""
+        mock_task = _make_task(TaskState.completed)
+        user_message = Message(
+            message_id="user-msg",
+            role=Role.user,
+            parts=[Part(root=TextPart(text="Echoed user prompt"))],
+        )
+
+        async def mock_stream(*args, **kwargs):
+            yield StreamEvent(
+                event_type="message",
+                text="Echoed user prompt",
+                message=user_message,
+            )
+            yield StreamEvent(
+                event_type="artifact",
+                text="First chunk ",
+                task=mock_task,
+            )
+            yield StreamEvent(
+                event_type="artifact",
+                text="Second chunk",
+                task=mock_task,
+            )
+
+        mock_service = MagicMock()
+        mock_service.stream = mock_stream
+
+        output = MagicMock(spec=Output)
+        output.output_format = "text"
+
+        with patch("a2a_handler.cli.message.update_session"):
+            await _stream_message(
+                mock_service,
+                "Hello",
+                None,
+                None,
+                "http://localhost:8000",
+                output,
+            )
+
+        output.text.assert_any_call("First chunk ", end="", flush=True)
+        output.text.assert_any_call("Second chunk", end="", flush=True)
+        assert all(
+            call.args != ("Echoed user prompt",) for call in output.text.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_message_prints_event_summaries_before_text(self):
+        """Test text streams include task/tool summaries before response text."""
+        mock_task = _make_task(TaskState.working)
+        tool_call = Message(
+            message_id="tool-call-msg",
+            role=Role.agent,
+            parts=[
+                Part(
+                    root=DataPart(
+                        data={
+                            "id": "call-1",
+                            "name": "search_a2a_protocol_docs",
+                            "args": {"query": "streaming"},
+                        }
+                    )
+                )
+            ],
+        )
+        answer = Message(
+            message_id="answer-msg",
+            role=Role.agent,
+            parts=[Part(root=TextPart(text="A2A supports streaming updates."))],
+        )
+
+        async def mock_stream(*args, **kwargs):
+            yield StreamEvent(
+                event_type="status",
+                task=mock_task,
+                status=TaskStatusUpdateEvent(
+                    task_id="task-123",
+                    context_id="ctx-123",
+                    final=False,
+                    status=TaskStatus(state=TaskState.working, message=tool_call),
+                ),
+            )
+            yield StreamEvent(
+                event_type="status",
+                task=mock_task,
+                status=TaskStatusUpdateEvent(
+                    task_id="task-123",
+                    context_id="ctx-123",
+                    final=False,
+                    status=TaskStatus(state=TaskState.working, message=answer),
+                ),
+            )
+
+        mock_service = MagicMock()
+        mock_service.stream = mock_stream
+
+        output = MagicMock(spec=Output)
+        output.output_format = "text"
+
+        with patch("a2a_handler.cli.message.update_session"):
+            await _stream_message(
+                mock_service,
+                "Hello",
+                None,
+                None,
+                "http://localhost:8000",
+                output,
+            )
+
+        calls = output.text.call_args_list
+        assert calls[0].args == ("event: task working (task-123)",)
+        assert calls[1].args == (
+            "event: tool call search_a2a_protocol_docs (task-123)",
+        )
+        assert calls[2].args == ("event: message text (task-123)",)
+        assert calls[3].args == ()
+        assert calls[3].kwargs == {"flush": True}
+        assert calls[4].args == ("A2A supports streaming updates.",)
+        assert calls[4].kwargs == {"end": "", "flush": True}
 
     @pytest.mark.asyncio
     async def test_stream_message_auth_required(self):
@@ -440,6 +606,7 @@ class TestStreamMessage:
         mock_service.stream = mock_stream
 
         output = MagicMock(spec=Output)
+        output.output_format = "json"
 
         with patch("a2a_handler.cli.message.update_session"):
             await _stream_message(
@@ -455,6 +622,38 @@ class TestStreamMessage:
         assert call_data["status"]["state"] == "auth-required"
 
     @pytest.mark.asyncio
+    async def test_stream_message_emits_ndjson_events(self):
+        """Test _stream_message emits each event in NDJSON mode."""
+        mock_task = _make_task(TaskState.completed)
+
+        async def mock_stream(*args, **kwargs):
+            yield StreamEvent(
+                event_type="artifact",
+                text="Chunk",
+                task=mock_task,
+            )
+
+        mock_service = MagicMock()
+        mock_service.stream = mock_stream
+
+        output = MagicMock(spec=Output)
+        output.output_format = "ndjson"
+
+        with patch("a2a_handler.cli.message.update_session"):
+            await _stream_message(
+                mock_service,
+                "Hello",
+                None,
+                None,
+                "http://localhost:8000",
+                output,
+            )
+
+        call_data = output.json.call_args[0][0]
+        assert call_data["type"] == "artifact"
+        assert call_data["text"] == "Chunk"
+
+    @pytest.mark.asyncio
     async def test_stream_message_no_response(self):
         """Test _stream_message emits error when no response received."""
 
@@ -466,6 +665,7 @@ class TestStreamMessage:
         mock_service.stream = mock_stream
 
         output = MagicMock(spec=Output)
+        output.output_format = "text"
 
         with patch("a2a_handler.cli.message.update_session"):
             await _stream_message(

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -330,7 +330,7 @@ class TestMessageStream:
         mock_task = _make_task(TaskState.completed)
 
         with (
-            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.build_streaming_http_client") as mock_client,
             patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
             patch("a2a_handler.cli.message.update_session"),
         ):
@@ -520,7 +520,8 @@ class TestStreamMessage:
     @pytest.mark.asyncio
     async def test_stream_message_prints_event_summaries_before_text(self):
         """Test text streams include task/tool summaries before response text."""
-        mock_task = _make_task(TaskState.working)
+        task_id = "task-1234567890abcdef"
+        mock_task = _make_task(TaskState.working, task_id=task_id)
         tool_call = Message(
             message_id="tool-call-msg",
             role=Role.agent,
@@ -547,7 +548,7 @@ class TestStreamMessage:
                 event_type="status",
                 task=mock_task,
                 status=TaskStatusUpdateEvent(
-                    task_id="task-123",
+                    task_id=task_id,
                     context_id="ctx-123",
                     final=False,
                     status=TaskStatus(state=TaskState.working, message=tool_call),
@@ -557,7 +558,7 @@ class TestStreamMessage:
                 event_type="status",
                 task=mock_task,
                 status=TaskStatusUpdateEvent(
-                    task_id="task-123",
+                    task_id=task_id,
                     context_id="ctx-123",
                     final=False,
                     status=TaskStatus(state=TaskState.working, message=answer),
@@ -581,15 +582,16 @@ class TestStreamMessage:
             )
 
         calls = output.text.call_args_list
-        assert calls[0].args == ("event: task working (task-123)",)
-        assert calls[1].args == (
+        assert calls[0].args == (f"task id: {task_id}",)
+        assert calls[1].args == ("event: task working (task-123)",)
+        assert calls[2].args == (
             "event: tool call search_a2a_protocol_docs (task-123)",
         )
-        assert calls[2].args == ("event: message text (task-123)",)
-        assert calls[3].args == ()
-        assert calls[3].kwargs == {"flush": True}
-        assert calls[4].args == ("A2A supports streaming updates.",)
-        assert calls[4].kwargs == {"end": "", "flush": True}
+        assert calls[3].args == ("event: message text (task-123)",)
+        assert calls[4].args == ()
+        assert calls[4].kwargs == {"flush": True}
+        assert calls[5].args == ("A2A supports streaming updates.",)
+        assert calls[5].kwargs == {"end": "", "flush": True}
 
     @pytest.mark.asyncio
     async def test_stream_message_auth_required(self):

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -20,7 +20,12 @@ from a2a.types import (
     TextPart,
 )
 
-from a2a_handler.cli.message import message, _format_response, _stream_message
+from a2a_handler.cli.message import (
+    message,
+    _format_response,
+    _stream_message,
+    _stream_text_delta,
+)
 from a2a_handler.common import Output
 from a2a_handler.service import StreamEvent
 
@@ -432,6 +437,12 @@ class TestFormatResponse:
 
 class TestStreamMessage:
     """Tests for _stream_message helper."""
+
+    def test_stream_text_delta_emits_repeated_non_snapshot_text(self):
+        """Repeated chunks are emitted unless they are exact cumulative snapshots."""
+        assert _stream_text_delta("OK", "OK") == ""
+        assert _stream_text_delta("Hello", "Hello world") == " world"
+        assert _stream_text_delta("OK, done", "OK") == "OK"
 
     @pytest.mark.asyncio
     async def test_stream_message_collects_response(self):

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -123,7 +123,7 @@ class TestSessionClear:
         result = runner.invoke(session, ["clear"])
 
         assert result.exit_code == 0
-        assert "missing_target" in result.output
+        assert "Provide --url or --server" in result.output
 
     def test_clear_rejects_invalid_agent_url(self, runner):
         """Test clearing a malformed URL fails with validation error."""

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -356,7 +356,7 @@ class TestTaskResubscribe:
             )
 
         with (
-            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.build_streaming_http_client") as mock_client,
             patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
         ):
             mock_http = AsyncMock()
@@ -389,7 +389,7 @@ class TestTaskResubscribe:
             yield StreamEvent(event_type="status", task=mock_task)
 
         with (
-            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.build_streaming_http_client") as mock_client,
             patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
         ):
             mock_http = AsyncMock()

--- a/tests/common/test_output.py
+++ b/tests/common/test_output.py
@@ -10,7 +10,7 @@ class TestOutput:
 
     def test_json(self, capsys):
         """Test JSON output."""
-        output = Output()
+        output = Output(output_format="json")
         output.json({"key": "value"})
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -20,7 +20,7 @@ class TestOutput:
         """Test JSON output with non-serializable type (uses default=str)."""
         from datetime import datetime
 
-        output = Output()
+        output = Output(output_format="json")
         now = datetime.now()
         output.json({"time": now})
         captured = capsys.readouterr()
@@ -29,7 +29,7 @@ class TestOutput:
 
     def test_error(self, capsys):
         """Test error output."""
-        output = Output()
+        output = Output(output_format="json")
         output.error(code="test_error", message="Something went wrong")
         captured = capsys.readouterr()
         data = json.loads(captured.err)
@@ -39,7 +39,7 @@ class TestOutput:
 
     def test_error_with_details(self, capsys):
         """Test error output with details and suggestion."""
-        output = Output()
+        output = Output(output_format="json")
         output.error(
             code="test_error",
             message="Something went wrong",
@@ -64,6 +64,28 @@ class TestOutput:
         output.error(code="x", message="bad")
         captured = capsys.readouterr()
         assert captured.err != ""
+
+    def test_json_output_stays_structured_by_default(self, capsys):
+        """json() keeps structured output by default."""
+        output = Output()
+        output.json({"key": "value", "items": ["one", "two"]})
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"key": "value", "items": ["one", "two"]}
+
+    def test_text_output(self, capsys):
+        """text() emits readable text."""
+        output = Output()
+        output.text("hello")
+        captured = capsys.readouterr()
+        assert captured.out == "hello\n"
+
+    def test_text_error_is_readable(self, capsys):
+        """Default errors render readable text."""
+        output = Output()
+        output.error(code="test_error", message="Something went wrong")
+        captured = capsys.readouterr()
+        assert "Error: Something went wrong" in captured.err
 
 
 class TestNdjsonOutput:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@
 import pytest
 
 from a2a_handler.common.output import configure_output
+from a2a_handler.cli._helpers import configure_http_timeouts
 
 
 @pytest.fixture(autouse=True)
 def reset_output_defaults():
     """Reset global output defaults to avoid cross-test leakage."""
     configure_output(output_format="text", quiet=False)
+    configure_http_timeouts()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,4 @@ from a2a_handler.common.output import configure_output
 @pytest.fixture(autouse=True)
 def reset_output_defaults():
     """Reset global output defaults to avoid cross-test leakage."""
-    configure_output(output_format="json", quiet=False)
+    configure_output(output_format="text", quiet=False)

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -15,6 +15,7 @@ from a2a.types import (
     TaskPushNotificationConfig,
     TaskState,
     TaskStatus,
+    TaskStatusUpdateEvent,
     TextPart,
 )
 from typing import cast
@@ -492,6 +493,40 @@ class TestA2AServiceStreamingCompatibility:
         assert events[0].event_type == "task"
         assert events[0].task_id == task.id
         assert events[0].text == extract_text_from_task(task)
+
+    async def test_stream_extracts_status_message_text(self):
+        """Test stream() does not stringify status message objects."""
+        task = _make_task(TaskState.working)
+        status_update = TaskStatusUpdateEvent(
+            task_id=task.id,
+            context_id=task.context_id,
+            final=False,
+            status=TaskStatus(
+                state=TaskState.working,
+                message=Message(
+                    message_id="msg-1",
+                    role=Role.agent,
+                    parts=[Part(root=TextPart(text="Working on it"))],
+                ),
+            ),
+        )
+        fake_client = _FakeStreamingClient(events=[(task, status_update)])
+
+        async with httpx.AsyncClient() as http_client:
+            service = A2AService(
+                http_client=http_client, agent_url="http://example.com"
+            )
+
+            async def _get_client():
+                return fake_client
+
+            service._get_or_create_client = _get_client  # type: ignore[method-assign]
+
+            events = [event async for event in service.stream("hello")]
+
+        assert len(events) == 1
+        assert events[0].event_type == "status"
+        assert events[0].text == "Working on it"
 
     async def test_resubscribe_handles_tuple_with_none_update(self):
         """Test resubscribe() maps tuple events with None update to task events."""


### PR DESCRIPTION
This pull request introduces significant improvements to the CLI's handling of output formats and HTTP timeouts, making it more flexible for both interactive and automated use cases. The default output is now human-readable text, with options for structured JSON and NDJSON, and new global timeout flags/environment variables have been added for fine-grained networking control. Documentation has been updated to explain these changes and provide usage examples.

**CLI Output and Timeout Enhancements:**

* The CLI now defaults to human-readable text output (`--output text`), with options for structured output (`--output json` or `--output ndjson`). Streaming commands in text mode print concise `event:` summaries for state changes, tool calls, etc., and always print the full task ID at stream start. NDJSON output is available for automation and agent-driven workflows. [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8L57-R123) [[2]](diffhunk://#diff-6604a09d994019984304bee150777f03cb18a43062dec55bc46bb503ffd515baR345-R350) [[3]](diffhunk://#diff-6604a09d994019984304bee150777f03cb18a43062dec55bc46bb503ffd515baR360-R638) [[4]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2L8-R11) [[5]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2R42-R76) [[6]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2L66-R103) [[7]](diffhunk://#diff-15e3dae83982c3ffca996f3390ec37adbd333dd6b7736f4809c97965f0da7888L82-R84) [[8]](diffhunk://#diff-01699295ce95f54097dfbfb1b208d5bd66ed4c1ecbfd24f49179a409965d502eL88)

* Added global HTTP timeout flags (`--connect-timeout`, `--read-timeout`, `--write-timeout`, `--pool-timeout`, `--stream-read-timeout`) and corresponding environment variables. These allow users to tune networking behavior for both regular and streaming requests; streaming disables read timeout by default to support long-running tasks. [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8L57-R123) [[2]](diffhunk://#diff-441f133d6a09ad632c8c505287c95537513bb3a6ba87126ae345dd3d9aa53fd7R30-R36) [[3]](diffhunk://#diff-441f133d6a09ad632c8c505287c95537513bb3a6ba87126ae345dd3d9aa53fd7L42-R151)

**Codebase Improvements:**

* Refactored HTTP client construction to use new timeout configuration helpers and to distinguish between regular and streaming clients, ensuring correct timeout behavior for each use case. [[1]](diffhunk://#diff-40ff8577a6a5617b76c97182efbf9d34ca88a5ae2ea018eaa39e201a014a6fc8R36) [[2]](diffhunk://#diff-441f133d6a09ad632c8c505287c95537513bb3a6ba87126ae345dd3d9aa53fd7L42-R151) [[3]](diffhunk://#diff-6604a09d994019984304bee150777f03cb18a43062dec55bc46bb503ffd515baL231-R239)

* Improved formatting and summarization of streaming events and responses for text output, including better handling of message parts, tool calls/results, and file parts. Added helper functions for formatting and emitting only new text deltas during streaming. [[1]](diffhunk://#diff-6604a09d994019984304bee150777f03cb18a43062dec55bc46bb503ffd515baR345-R350) [[2]](diffhunk://#diff-6604a09d994019984304bee150777f03cb18a43062dec55bc46bb503ffd515baR360-R638)

* Updated documentation to reflect new defaults, output modes, and timeout options, with clear examples for both interactive and automated workflows. [[1]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2L8-R11) [[2]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2R42-R76) [[3]](diffhunk://#diff-c62e553d8e51b7381030a77309eacb9e82c2474c1c272f9219a5343f3fe326a2L66-R103) [[4]](diffhunk://#diff-15e3dae83982c3ffca996f3390ec37adbd333dd6b7736f4809c97965f0da7888L82-R84) [[5]](diffhunk://#diff-01699295ce95f54097dfbfb1b208d5bd66ed4c1ecbfd24f49179a409965d502eL88)

Resolves #63 