### PR TITLE
ci: verify a lockfile-free install, and gate the release on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    # Nothing to learn from a nightly run: this job resolves through uv.lock
+    # against unchanged code, so on a timer it can only fail spuriously. The
+    # scheduled trigger exists for fresh-install alone.
+    if: github.event_name != 'schedule'
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,49 +49,7 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-  # Every check above resolves through uv.lock, which is exactly what hid the
-  # mcp 2.0 breakage in v0.1.25: the lock pinned a working version while the
-  # published metadata let end users resolve a broken one. This job throws the
-  # lockfile away and installs the built wheel the way a user actually does, so
-  # an unbounded dependency fails here instead of on someone's machine.
+  # The only job whose result can change without a commit, which is why the
+  # schedule trigger above exists. Shared with release.yml.
   fresh-install:
-    name: Fresh install (no lockfile)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # Ends of the supported range from requires-python.
-        python-version: [ "3.11", "3.13" ]
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        # Deliberately uncached: a stale index would hide a newly published
-        # breaking release, which is the whole thing this job exists to catch.
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: false
-
-      - name: Set up Python
-        run: uv python install ${{ matrix.python-version }}
-
-      - name: Build the distribution
-        run: uv build
-
-      - name: Install the wheel, resolving dependencies from scratch
-        run: |
-          uv venv --python ${{ matrix.python-version }} /tmp/smoke
-          uv pip install --python /tmp/smoke/bin/python --refresh dist/*.whl
-
-      - name: Report the resolved dependency versions
-        # Printed unconditionally: when this job fails, the resolution it picked
-        # is the first thing you need to see.
-        run: uv pip list --python /tmp/smoke/bin/python
-
-      - name: Smoke-test the installed entrypoint
-        # Exercises the full import chain, which is where the mcp 2.0 break
-        # surfaced -- the CLI could not start at all.
-        run: |
-          /tmp/smoke/bin/handler --version
-          /tmp/smoke/bin/handler --help > /dev/null
+    uses: ./.github/workflows/fresh-install.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # A dependency can publish a breaking release with no commit on our side, so
+  # the fresh-install job below has to run on a timer to be worth anything.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -39,3 +44,50 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  # Every check above resolves through uv.lock, which is exactly what hid the
+  # mcp 2.0 breakage in v0.1.25: the lock pinned a working version while the
+  # published metadata let end users resolve a broken one. This job throws the
+  # lockfile away and installs the built wheel the way a user actually does, so
+  # an unbounded dependency fails here instead of on someone's machine.
+  fresh-install:
+    name: Fresh install (no lockfile)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Ends of the supported range from requires-python.
+        python-version: [ "3.11", "3.13" ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        # Deliberately uncached: a stale index would hide a newly published
+        # breaking release, which is the whole thing this job exists to catch.
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
+
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Build the distribution
+        run: uv build
+
+      - name: Install the wheel, resolving dependencies from scratch
+        run: |
+          uv venv --python ${{ matrix.python-version }} /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python --refresh dist/*.whl
+
+      - name: Report the resolved dependency versions
+        # Printed unconditionally: when this job fails, the resolution it picked
+        # is the first thing you need to see.
+        run: uv pip list --python /tmp/smoke/bin/python
+
+      - name: Smoke-test the installed entrypoint
+        # Exercises the full import chain, which is where the mcp 2.0 break
+        # surfaced -- the CLI could not start at all.
+        run: |
+          /tmp/smoke/bin/handler --version
+          /tmp/smoke/bin/handler --help > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,14 @@ jobs:
 
   # The only job whose result can change without a commit, which is why the
   # schedule trigger above exists. Shared with release.yml.
+  #
+  # One version on purpose. What this catches is a dependency publishing a
+  # release our constraints fail to exclude, which breaks every interpreter
+  # identically -- a matrix here would multiply the nightly notifications
+  # without adding a signal. The floor is the more sensitive single choice,
+  # since it also catches a dependency dropping our minimum. The full range
+  # runs at release time, where being exhaustive is worth the cost.
   fresh-install:
     uses: ./.github/workflows/fresh-install.yml
+    with:
+      python-versions: '["3.11"]'

--- a/.github/workflows/fresh-install.yml
+++ b/.github/workflows/fresh-install.yml
@@ -1,0 +1,56 @@
+name: Fresh install
+
+# Called by both ci.yml and release.yml so the two cannot drift. Every other
+# check in this repo resolves through uv.lock, which is exactly what hid the
+# mcp 2.0 breakage in v0.1.25: the lock pinned a working version while the
+# published metadata let end users resolve a broken one. This throws the
+# lockfile away and installs the built wheel the way a user actually does, so
+# an unbounded dependency fails here instead of on someone's machine.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  fresh-install:
+    name: Fresh install (no lockfile)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Ends of the supported range from requires-python.
+        python-version: [ "3.11", "3.13" ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        # Deliberately uncached: a stale index would hide a newly published
+        # breaking release, which is the whole thing this job exists to catch.
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: false
+
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Build the distribution
+        run: uv build
+
+      - name: Install the wheel, resolving dependencies from scratch
+        run: |
+          uv venv --python ${{ matrix.python-version }} /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python --refresh dist/*.whl
+
+      - name: Report the resolved dependency versions
+        # Printed unconditionally: when this job fails, the resolution it picked
+        # is the first thing you need to see.
+        run: uv pip list --python /tmp/smoke/bin/python
+
+      - name: Smoke-test the installed entrypoint
+        # Exercises the full import chain, which is where the mcp 2.0 break
+        # surfaced -- the CLI could not start at all.
+        run: |
+          /tmp/smoke/bin/handler --version
+          /tmp/smoke/bin/handler --help > /dev/null

--- a/.github/workflows/fresh-install.yml
+++ b/.github/workflows/fresh-install.yml
@@ -8,6 +8,17 @@ name: Fresh install
 # an unbounded dependency fails here instead of on someone's machine.
 on:
   workflow_call:
+    inputs:
+      python-versions:
+        description: >
+          JSON array of Python versions to test. Defaults to every version
+          declared in the classifiers, which is what a release should be held
+          to. Callers on a timer should pass a single version instead: this
+          job detects dependency-resolution drift, which is a property of
+          published metadata rather than of Python semantics, so extra
+          versions cost notifications without adding signal.
+        type: string
+        default: '["3.11", "3.12", "3.13", "3.14"]'
 
 permissions:
   contents: read
@@ -19,8 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Ends of the supported range from requires-python.
-        python-version: [ "3.11", "3.13" ]
+        python-version: ${{ fromJson(inputs.python-versions) }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,17 @@ permissions:
   id-token: write
 
 jobs:
+  # Gate the whole release on a lockfile-free install. Everything in the job
+  # below resolves through uv.lock, so on its own it cannot tell whether the
+  # artifact it is about to publish is installable by anyone else -- that is
+  # how v0.1.25 shipped green and broken. Nothing is tagged, released, or
+  # published to PyPI unless this passes.
+  fresh-install:
+    uses: ./.github/workflows/fresh-install.yml
+
   release:
     name: Create Release
+    needs: fresh-install
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
   # artifact it is about to publish is installable by anyone else -- that is
   # how v0.1.25 shipped green and broken. Nothing is tagged, released, or
   # published to PyPI unless this passes.
+  #
+  # Inherits the default matrix: every Python version in the classifiers.
+  # Exhaustive here rather than sampled as the nightly run is, because a bad
+  # release cannot be taken back -- PyPI refuses to let a version number be
+  # reused, so the only remedy is shipping another version on top of it.
   fresh-install:
     uses: ./.github/workflows/fresh-install.yml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
Follow-up to the v0.1.26 hotfix. That release was broken for five days without CI noticing; this closes both halves of the gap that allowed it.

## The gap

Every check we run — including `release.yml` — resolves through `uv.lock`. That is precisely the file that hid the problem:

- `uv.lock` pinned `mcp==1.28.1`, so CI and local dev were green.
- The published wheel declared `mcp[cli]>=1.27.1` with no upper bound.
- `uv tool install` / `uvx` / `pip` ignore the lockfile and resolve from that metadata, so users got `mcp` 2.0.0, which dropped `mcp.shared.session` that `google-adk` still imports.

Nothing we tested looked at what users actually install, so the release went out green on the day it was already doomed.

## The change

A `fresh-install` job that discards the lockfile and installs the built wheel the way a user does. It lives in a reusable workflow called from two places, because there are two distinct failure modes with different needs:

| Failure mode | Caught by | Versions |
|---|---|---|
| A dependency is **already broken** when we ship | `release.yml` gate — `release` now `needs: fresh-install`, and `publish` already needs `release`, so nothing reaches PyPI unless it passes | all declared (3.11–3.14) |
| A dependency **breaks after** we ship | nightly cron in `ci.yml` — needs no commit on our side, so a push-only trigger would never fire | 3.11 only |

v0.1.25 was the second kind: `mcp` 2.0.0 landed five days after the tag, with zero commits in between.

**Why one version nightly.** This detects a dependency publishing a release our constraints fail to exclude. That breaks every interpreter identically, so a matrix multiplies notifications without adding signal. The floor is the more sensitive single choice — it also catches a dependency quietly dropping our minimum.

**Why exhaustive at release.** A bad release cannot be retracted; PyPI will not let a version number be reused, so the only remedy is shipping another version on top of it.

Extracted into a reusable workflow rather than copied, so the gate and the canary cannot drift apart.

## Also: declare 3.14

`requires-python` is `>=3.11` with no upper bound, so 3.14 installs fine and is what `uv` selects by default now — but the classifiers stopped at 3.13. Leaving it undeclared would have handed the release gate the same blind spot it exists to close: the interpreter most new installs land on, untested. It works, so it is now declared.

## Verification

The canary actually fires rather than merely passing:

| Scenario | Resolved | `handler --version` |
|---|---|---|
| Broken `0.1.25`, fresh resolve | `mcp 2.0.0` | exit **1** — job goes red |
| Fixed `0.1.26` on 3.11 / 3.12 / 3.13 / 3.14 | `mcp 1.29.0` | exit 0 on all four |

`actionlint` reports 0 errors across all three workflows, and I confirmed it catches a bad reusable-workflow path rather than silently passing.

**Limitation:** `release.yml` only runs on a tag push, which publishes to PyPI, so the gate has not been exercised end to end. What is proven is that the reusable workflow runs correctly when called from `ci.yml`, and that both callers reference it with a byte-identical `uses:` path. The untested piece is the `needs:` wiring, which actionlint validates statically.

Smaller choices: `Check` is skipped on schedule (it resolves through the lockfile against unchanged code, so nightly it can only fail spuriously); the canary's uv cache is disabled (a stale index would hide the newly published release it exists to find); cost is zero on a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)