### PR TITLE
docs: drop remaining built-in agent references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 - **Python 3.11+**
 - **[uv](https://github.com/astral-sh/uv)** for dependency management
 - **[just](https://github.com/casey/just)** for running commands
-- **[Ollama](https://ollama.com/)** (optional, for running the server agent)
 
 ## Setup
 

--- a/docs/guides/local-servers.mdx
+++ b/docs/guides/local-servers.mdx
@@ -3,7 +3,7 @@ title: "Local servers"
 description: "Run Handler's local webhook server for development, demos, and integration testing."
 ---
 
-# Run local A2A servers
+# Run the local webhook server
 
 Handler ships with a local webhook receiver for task push notifications, which
 is useful for development work and integration testing.


### PR DESCRIPTION
Two leftovers from #92, found while auditing docs ahead of the v0.2.0 release.

- **CONTRIBUTING** listed Ollama as an optional prerequisite "for running the server agent" — that agent no longer exists.
- **`local-servers.mdx`** was rewritten to cover only the push notification receiver, but kept its `Run local A2A servers` heading. The webhook receiver is not an A2A server, and there is no longer more than one, so the heading now names what the page actually documents. The nav title in `docs.json` is unchanged.

Docs-only; no code or dependency changes.

Verified alongside this: every command in `docs/reference/cli.mdx` exists in the CLI and every leaf command is documented, all 11 nav pages resolve to files on disk with no orphans, and a repo-wide sweep for agent/Ollama/LiteLLM/ADK references now comes back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)