### PR TITLE
feat(tui): stream replies, cancel tasks, and handle input-required

### DIFF
--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -234,7 +234,13 @@ def extract_text_from_message_parts(message_parts: Iterable[Part] | None) -> str
 
 
 def extract_text_from_task(task: Task) -> str:
-    """Extract text from task artifacts, falling back to history if no artifacts."""
+    """Extract an agent's text from a task.
+
+    Prefers artifacts, then agent messages in history, then the status message.
+    The last of those matters for a task that pauses rather than finishes: an
+    agent asking a question often carries it only on the status, and without
+    this fallback the user is shown a paused task with nothing to read.
+    """
     extracted_texts = []
 
     if task.artifacts:
@@ -247,6 +253,11 @@ def extract_text_from_task(task: Task) -> str:
         for message in task.history:
             if message.role == Role.ROLE_AGENT and message.parts:
                 extracted_texts.append(extract_text_from_message_parts(message.parts))
+
+    if not any(extracted_texts) and task.status.HasField("message"):
+        extracted_texts.append(
+            extract_text_from_message_parts(task.status.message.parts)
+        )
 
     return "\n".join(text for text in extracted_texts if text)
 

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -59,6 +59,43 @@ TERMINAL_TASK_STATES = {
     TaskState.TASK_STATE_REJECTED,
 }
 
+# States where the task is still open but the agent has handed control back and
+# will not progress until the client acts. A client that waits for a terminal
+# state without checking these will hang forever.
+INTERRUPTED_TASK_STATES = {
+    TaskState.TASK_STATE_INPUT_REQUIRED,
+    TaskState.TASK_STATE_AUTH_REQUIRED,
+}
+
+
+def state_is_terminal(state: int | None) -> bool:
+    """Return whether a task state means the task will never progress further."""
+    return state in TERMINAL_TASK_STATES if state else False
+
+
+def state_is_interrupted(state: int | None) -> bool:
+    """Return whether a task is paused waiting on the client."""
+    return state in INTERRUPTED_TASK_STATES if state else False
+
+
+def state_needs_input(state: int | None) -> bool:
+    """Return whether the agent is waiting for another message from the user."""
+    return state == TaskState.TASK_STATE_INPUT_REQUIRED
+
+
+def state_needs_auth(state: int | None) -> bool:
+    """Return whether the agent is waiting for the client to authenticate."""
+    return state == TaskState.TASK_STATE_AUTH_REQUIRED
+
+
+def state_is_settled(state: int | None) -> bool:
+    """Return whether a turn should stop waiting on this state.
+
+    A turn ends either because the task finished or because the agent handed
+    control back to the client.
+    """
+    return state_is_terminal(state) or state_is_interrupted(state)
+
 
 def to_json_dict(message: Any) -> dict[str, Any]:
     """Serialize an A2A protobuf message to its canonical JSON dict.
@@ -238,13 +275,29 @@ def response_state(response: A2AResponse) -> int | None:
 
 def is_terminal(response: A2AResponse) -> bool:
     """Check if the response reached a terminal state."""
-    state = response_state(response)
-    return state in TERMINAL_TASK_STATES if state else False
+    return state_is_terminal(response_state(response))
 
 
 def response_needs_auth(response: A2AResponse) -> bool:
     """Check if the response requires authentication."""
-    return response_state(response) == TaskState.TASK_STATE_AUTH_REQUIRED
+    return state_needs_auth(response_state(response))
+
+
+def response_needs_input(response: A2AResponse) -> bool:
+    """Check if the agent is waiting for another message from the user."""
+    return state_needs_input(response_state(response))
+
+
+def continuation_task_id(response: A2AResponse) -> str | None:
+    """Return the task ID a follow-up message should continue, if any.
+
+    A terminal task cannot accept more messages, so it yields ``None``. An
+    interrupted task (input or auth required) is still open and must be
+    continued by ID, otherwise the agent loses the thread.
+    """
+    if is_terminal(response):
+        return None
+    return response_task_id(response)
 
 
 def extract_text(response: A2AResponse) -> str:

--- a/src/a2a_handler/tui/app.tcss
+++ b/src/a2a_handler/tui/app.tcss
@@ -441,6 +441,15 @@ Select:focus SelectCurrent {
     text-style: bold;
 }
 
+#cancel-btn {
+    width: auto;
+    min-width: 8;
+    margin-right: 1;
+    background: $error 25%;
+    color: $text;
+    text-style: bold;
+}
+
 #connect-btn {
     width: 13;
     min-width: 13;
@@ -525,6 +534,19 @@ Message.message-system {
 AgentMessage {
     color: $text;
     background: $accent 8%;
+}
+
+StreamingMessage {
+    color: $text;
+    background: $accent 8%;
+    height: auto;
+    margin: 0 0 1 0;
+    padding: 1 2;
+}
+
+StreamingMessage .message-stream-state {
+    color: $accent;
+    text-style: bold;
 }
 
 .message-header {

--- a/src/a2a_handler/tui/components/input.py
+++ b/src/a2a_handler/tui/components/input.py
@@ -16,6 +16,7 @@ class InputPanel(Container):
     DEFAULT_PLACEHOLDER = "Type your message..."
     DISCONNECTED_PLACEHOLDER = "Connect to an agent to start chatting."
     WAITING_PLACEHOLDER = "Waiting for agent response..."
+    INPUT_REQUIRED_PLACEHOLDER = "The agent is waiting for your reply..."
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="input-row"):
@@ -24,11 +25,22 @@ class InputPanel(Container):
             yield Static(
                 "Waiting for agent...", id="send-loading-label", classes="hidden"
             )
+            yield Button("STOP", id="cancel-btn", variant="error", classes="hidden")
             yield Button("SEND", id="send-btn")
 
     def on_mount(self) -> None:
         self.query_one("#send-btn", Button).can_focus = False
+        self.query_one("#cancel-btn", Button).can_focus = False
         logger.debug("Input panel mounted")
+
+    def set_status(self, text: str) -> None:
+        """Update the in-flight label with the agent's current state."""
+        self.query_one("#send-loading-label", Static).update(text)
+
+    def prompt_for_reply(self) -> None:
+        """Signal that the agent asked a question and is waiting on the user."""
+        message_input = self.query_one("#message-input", Input)
+        message_input.placeholder = self.INPUT_REQUIRED_PLACEHOLDER
 
     def get_message(self) -> str:
         """Get and clear the current message input."""
@@ -56,22 +68,32 @@ class InputPanel(Container):
         message_input.placeholder = self.DISCONNECTED_PLACEHOLDER
         loading.add_class("hidden")
         label.add_class("hidden")
+        self.query_one("#cancel-btn", Button).add_class("hidden")
 
-    def set_waiting(self, waiting: bool) -> None:
-        """Show or hide the in-flight request indicator."""
+    def set_waiting(self, waiting: bool, *, cancellable: bool = False) -> None:
+        """Show or hide the in-flight request indicator.
+
+        ``cancellable`` reveals the stop control, which is only meaningful for
+        a streaming turn the client can actually interrupt.
+        """
         message_input = self.query_one("#message-input", Input)
         send_button = self.query_one("#send-btn", Button)
         loading = self.query_one("#send-loading", LoadingIndicator)
         label = self.query_one("#send-loading-label", Static)
+        cancel_button = self.query_one("#cancel-btn", Button)
 
         message_input.disabled = waiting
         send_button.disabled = waiting
         if waiting:
             message_input.placeholder = self.WAITING_PLACEHOLDER
+            label.update("Waiting for agent...")
             loading.remove_class("hidden")
             label.remove_class("hidden")
+            cancel_button.set_class(not cancellable, "hidden")
+            cancel_button.disabled = not cancellable
             return
 
         message_input.placeholder = self.DEFAULT_PLACEHOLDER
         loading.add_class("hidden")
         label.add_class("hidden")
+        cancel_button.add_class("hidden")

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -138,6 +138,68 @@ class Message(Container):
         self.app.open_url(url)
 
 
+class StreamingMessage(Container):
+    """A live agent reply, updated in place while a turn is still running.
+
+    This widget is transient: once the turn settles it is removed and replaced
+    by a regular :class:`AgentMessage`, so the finished transcript looks the
+    same whether or not the reply arrived incrementally.
+    """
+
+    PLACEHOLDER = "Waiting for the agent..."
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.add_class("message-agent")
+        self.add_class("message-streaming")
+        self._status = "working"
+        self._narration = ""
+        self._output: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(classes="message-header"):
+            yield Static("Agent", classes="message-role")
+            yield Static(self._status, classes="message-time message-stream-state")
+        yield Static(self.PLACEHOLDER, classes="message-body message-body-plain")
+
+    def on_mount(self) -> None:
+        for widget in self.query("Static"):
+            widget.can_focus = False
+
+    @property
+    def body_text(self) -> str:
+        """Return the text currently shown, for tests and transcript scans."""
+        return self._render_body()
+
+    def set_state(self, state: int | None, narration: str = "") -> None:
+        """Update the live state chip and any narration the agent sent."""
+        self._status = state_label(state)
+        if narration:
+            self._narration = narration
+        self._refresh()
+
+    def append_output(self, text: str) -> None:
+        """Append artifact text as the agent produces it."""
+        if text and text not in self._output:
+            self._output.append(text)
+        self._refresh()
+
+    def _render_body(self) -> str:
+        if self._output:
+            return "\n\n".join(self._output)
+        if self._narration:
+            return self._narration
+        return self.PLACEHOLDER
+
+    def _refresh(self) -> None:
+        """Push current state into the mounted widgets, if they exist yet."""
+        try:
+            self.query_one(".message-stream-state", Static).update(self._status)
+            self.query_one(".message-body", Static).update(self._render_body())
+        except Exception:  # noqa: BLE001 - not mounted yet; compose() will render
+            logger.debug("Streaming message not mounted yet; deferring update")
+
+
 class AgentMessage(Message):
     """An agent message with A2A protocol metadata."""
 
@@ -326,6 +388,24 @@ class TabbedMessagesPanel(Container):
     def add_system_message(self, content: str) -> None:
         logger.info("System message: %s", content)
         self.add_message("system", content)
+
+    def begin_agent_stream(self) -> StreamingMessage:
+        """Mount a live agent reply and return it for incremental updates."""
+        self.end_agent_stream()
+        chat_container = self._get_chat_container()
+        streaming = StreamingMessage(id="streaming-message")
+        chat_container.mount(streaming)
+        chat_container.scroll_end(animate=False)
+        return streaming
+
+    def end_agent_stream(self) -> None:
+        """Remove the live agent reply, if one is mounted."""
+        for widget in self.query("#streaming-message"):
+            widget.remove()
+
+    def scroll_chat_to_end(self) -> None:
+        """Keep the newest content in view while a reply streams in."""
+        self._get_chat_container().scroll_end(animate=False)
 
     def add_log(self, line: str) -> None:
         """Add a log line to the logs panel."""

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -207,9 +207,13 @@ class AgentMessage(Message):
         self,
         response: A2AResponse,
         timestamp: datetime | None = None,
+        fallback_text: str = "",
         **kwargs: Any,
     ) -> None:
-        content = extract_text(response) or "(no text in response)"
+        # A canceled or interrupted task often carries no text of its own. The
+        # fallback is what the agent last said while streaming, which beats
+        # telling the user there was no response to something they watched.
+        content = extract_text(response) or fallback_text or "(no text in response)"
         self.task_id = response_task_id(response)
         self.context_id = response_context_id(response)
         self.artifacts = (
@@ -374,14 +378,14 @@ class TabbedMessagesPanel(Container):
         chat_container.mount(message_widget)
         chat_container.scroll_end(animate=False)
 
-    def add_agent_message(self, response: A2AResponse) -> None:
+    def add_agent_message(self, response: A2AResponse, fallback_text: str = "") -> None:
         logger.debug(
             "Adding agent message - task_id=%s, state=%s",
             response_task_id(response),
             response_state(response),
         )
         chat_container = self._get_chat_container()
-        message_widget = AgentMessage(response)
+        message_widget = AgentMessage(response, fallback_text=fallback_text)
         chat_container.mount(message_widget)
         chat_container.scroll_end(animate=False)
 

--- a/src/a2a_handler/tui/components/messages.py
+++ b/src/a2a_handler/tui/components/messages.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
-from a2a.types import Task
+from a2a.types import Task, TaskState
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -200,6 +200,20 @@ class StreamingMessage(Container):
             logger.debug("Streaming message not mounted yet; deferring update")
 
 
+def _empty_body(state: int | None) -> str:
+    """Describe a reply that carries no text, without claiming the agent was silent.
+
+    A task stopped before the agent said anything is a different thing from a
+    task that finished with nothing to show, and the user watched one of them
+    happen.
+    """
+    if state == TaskState.TASK_STATE_CANCELED:
+        return "(stopped before the agent replied)"
+    if state == TaskState.TASK_STATE_FAILED:
+        return "(the task failed without a message)"
+    return "(no text in response)"
+
+
 class AgentMessage(Message):
     """An agent message with A2A protocol metadata."""
 
@@ -213,7 +227,11 @@ class AgentMessage(Message):
         # A canceled or interrupted task often carries no text of its own. The
         # fallback is what the agent last said while streaming, which beats
         # telling the user there was no response to something they watched.
-        content = extract_text(response) or fallback_text or "(no text in response)"
+        content = (
+            extract_text(response)
+            or fallback_text
+            or _empty_body(response_state(response))
+        )
         self.task_id = response_task_id(response)
         self.context_id = response_context_id(response)
         self.artifacts = (

--- a/src/a2a_handler/tui/server/tab.py
+++ b/src/a2a_handler/tui/server/tab.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 from collections.abc import Generator
 from typing import Any
@@ -54,6 +55,10 @@ from a2a_handler.tui.server.types import (
 from a2a_handler.tui.server.views import ConnectionBar, ServerView
 
 logger = get_logger(__name__)
+
+# How long to let an agent acknowledge a cancel before stopping locally.
+CANCEL_GRACE_SECONDS = 2.0
+CANCEL_POLL_SECONDS = 0.05
 
 
 class ServerTab(Container):
@@ -641,7 +646,14 @@ class ServerTab(Container):
         await self.cancel_active_turn()
 
     async def cancel_active_turn(self) -> None:
-        """Stop the in-flight turn, asking the agent to cancel its task."""
+        """Stop the in-flight turn, asking the agent to cancel its task.
+
+        The agent is asked first, then given a moment to acknowledge. An
+        acknowledged cancel arrives as a ``canceled`` status and settles the
+        turn normally, which keeps the task and everything the agent said. Only
+        an agent that ignores the request gets the worker pulled out from under
+        it, so the composer always comes back either way.
+        """
         turn = self._active_turn
         if turn is None:
             return
@@ -657,9 +669,26 @@ class ServerTab(Container):
                 "the server."
             )
 
+        if await self._turn_settles_within(CANCEL_GRACE_SECONDS):
+            return
+
+        logger.info(
+            "Agent did not acknowledge cancel within %ss; stopping locally",
+            CANCEL_GRACE_SECONDS,
+        )
         worker = self._send_worker
         if worker is not None:
             worker.cancel()
+
+    async def _turn_settles_within(self, seconds: float) -> bool:
+        """Wait briefly for the in-flight turn to finish on its own."""
+        deadline = seconds
+        while deadline > 0:
+            if self._active_turn is None:
+                return True
+            await asyncio.sleep(CANCEL_POLL_SECONDS)
+            deadline -= CANCEL_POLL_SECONDS
+        return self._active_turn is None
 
     @work(exclusive=True)
     async def _send_message(self) -> None:
@@ -787,6 +816,10 @@ class ServerTab(Container):
         response = result.response
         if response is not None:
             messages_panel.add_agent_message(response, result.narration)
+        elif result.narration:
+            # A turn stopped before the agent sent a final task still produced
+            # work the user watched. Keep it rather than drop the exchange.
+            messages_panel.add_message("agent", result.narration)
             if isinstance(response, Task):
                 messages_panel.update_task(response)
                 for artifact in response.artifacts or []:

--- a/src/a2a_handler/tui/server/tab.py
+++ b/src/a2a_handler/tui/server/tab.py
@@ -7,13 +7,13 @@ from collections.abc import Generator
 from typing import Any
 
 import httpx
-from a2a.client.errors import A2AClientError
 from a2a.types import AgentCard, Message as A2AMessage, Role, Task, TaskState
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.message import Message as TextualMessage
 from textual.widgets import Button, Input, RadioSet, Select
+from textual.worker import Worker
 
 from a2a_handler.auth import AuthCredentials, AuthType
 from a2a_handler.common import get_logger
@@ -32,13 +32,14 @@ from a2a_handler.service import (
     A2AService,
     card_protocol_version,
     extract_text_from_message_parts,
-    is_terminal,
-    response_context_id,
     response_task_id,
     response_state,
+    state_label,
 )
 from a2a_handler.session import get_session_store
 from a2a_handler.tui.components import TabbedMessagesPanel
+from a2a_handler.tui.components.messages import StreamingMessage
+from a2a_handler.turn import AgentTurn, TurnEvent, TurnEventKind, TurnResult
 from a2a_handler.tui.server.session import resolve_saved_conversation
 from a2a_handler.tui.server.types import (
     MANUAL_SERVER_ID,
@@ -91,6 +92,8 @@ class ServerTab(Container):
         self._syncing_auth_depth = 0
         self._suspend_connect_events = False
         self._log_lines: list[str] = []
+        self._active_turn: AgentTurn | None = None
+        self._send_worker: Worker[None] | None = None
 
     def compose(self) -> ComposeResult:
         yield ServerView()
@@ -621,13 +624,42 @@ class ServerTab(Container):
 
     @on(Input.Submitted, "#message-input")
     def handle_message_submit(self) -> None:
-        if self.is_connected:
-            self._send_message()
+        self._start_send()
 
     @on(Button.Pressed, "#send-btn")
     def handle_send_button(self) -> None:
-        if self.is_connected:
-            self._send_message()
+        self._start_send()
+
+    def _start_send(self) -> None:
+        """Start a turn, keeping the worker handle so it can be canceled."""
+        if not self.is_connected or self._active_turn is not None:
+            return
+        self._send_worker = self._send_message()
+
+    @on(Button.Pressed, "#cancel-btn")
+    async def _handle_cancel_pressed(self) -> None:
+        await self.cancel_active_turn()
+
+    async def cancel_active_turn(self) -> None:
+        """Stop the in-flight turn, asking the agent to cancel its task."""
+        turn = self._active_turn
+        if turn is None:
+            return
+
+        server_view = self._try_get_server_view()
+        if server_view is not None:
+            server_view.input_panel().set_status("Canceling...")
+
+        sent = await turn.request_cancel()
+        if server_view is not None and not sent:
+            server_view.messages_panel().add_system_message(
+                "The agent could not cancel this task; it may keep running on "
+                "the server."
+            )
+
+        worker = self._send_worker
+        if worker is not None:
+            worker.cancel()
 
     @work(exclusive=True)
     async def _send_message(self) -> None:
@@ -647,77 +679,137 @@ class ServerTab(Container):
 
         messages_panel = server_view.messages_panel()
         messages_panel.add_message("user", message_text)
-        input_panel.set_waiting(True)
 
         try:
             credentials = messages_panel.get_auth_credentials()
-            if credentials is not None:
-                self._agent_service.set_credentials(credentials)
-            else:
-                self._agent_service.clear_credentials()
+        except InputValidationError as error:
+            messages_panel.add_system_message(f"Error: {error.message}")
+            return
 
-            self._refresh_status_badges()
+        if credentials is not None:
+            self._agent_service.set_credentials(credentials)
+        else:
+            self._agent_service.clear_credentials()
+        self._refresh_status_badges()
 
-            try:
-                response = await self._agent_service.send(
-                    message_text,
-                    context_id=self.state.current_context_id,
-                    task_id=self.state.current_task_id,
+        turn = AgentTurn(
+            service=self._agent_service,
+            text=message_text,
+            context_id=self.state.current_context_id,
+            task_id=self.state.current_task_id,
+        )
+        self._active_turn = turn
+        live = messages_panel.begin_agent_stream()
+        input_panel.set_waiting(True, cancellable=True)
+
+        try:
+            async for event in turn.events():
+                self._apply_turn_event(server_view, live, event)
+        finally:
+            self._finish_turn(server_view, turn)
+
+    def _apply_turn_event(
+        self,
+        server_view: ServerView,
+        live: StreamingMessage,
+        event: TurnEvent,
+    ) -> None:
+        """Reflect one in-flight turn event in the live view."""
+        messages_panel = server_view.messages_panel()
+
+        if event.kind is TurnEventKind.NOTICE:
+            messages_panel.add_system_message(event.text)
+            return
+
+        if event.kind is TurnEventKind.STATUS:
+            live.set_state(event.state, event.text)
+            server_view.input_panel().set_status(
+                f"Agent is {state_label(event.state)}..."
+            )
+        elif event.kind is TurnEventKind.ARTIFACT:
+            live.append_output(event.text)
+            if event.artifact is not None:
+                task_id = (
+                    self._active_turn.active_task_id if self._active_turn else None
                 )
-            except Exception as error:
-                if self.state.current_task_id and self._is_uncontinuable_task_error(
-                    error
-                ):
-                    logger.info(
-                        "Retrying %s without active task_id %s",
-                        self.server_id,
-                        self.state.current_task_id,
-                    )
-                    self._clear_current_task_id()
-                    messages_panel.add_system_message(
-                        "Saved task can no longer accept messages; retrying with the saved context only."
-                    )
-                    response = await self._agent_service.send(
-                        message_text,
-                        context_id=self.state.current_context_id,
-                        task_id=None,
-                    )
-                else:
-                    raise
+                messages_panel.update_artifact(
+                    event.artifact,
+                    task_id or "",
+                    self.state.current_context_id or "",
+                )
+        elif event.kind is TurnEventKind.MESSAGE:
+            live.append_output(event.text)
 
-            ctx_id = response_context_id(response)
-            if ctx_id:
-                self.state.current_context_id = ctx_id
-            next_task_id = response_task_id(response)
-            self.state.current_task_id = None if is_terminal(response) else next_task_id
-            self._persist_session_state()
+        if event.task is not None:
+            messages_panel.update_task(event.task)
+        messages_panel.scroll_chat_to_end()
 
+    def _finish_turn(self, server_view: ServerView, turn: AgentTurn) -> None:
+        """Tear down the live view and apply the turn's outcome."""
+        self._active_turn = None
+        self._send_worker = None
+
+        messages_panel = server_view.messages_panel()
+        messages_panel.end_agent_stream()
+
+        result = turn.result
+        if result is not None:
+            self._apply_turn_result(server_view, result)
+
+        if self.is_connected:
+            input_panel = server_view.input_panel()
+            input_panel.set_waiting(False)
+            if result is not None and result.awaiting_input:
+                input_panel.prompt_for_reply()
+            input_panel.focus_input()
+
+    def _apply_turn_result(
+        self,
+        server_view: ServerView,
+        result: TurnResult,
+    ) -> None:
+        """Persist the outcome of a turn and render its final message."""
+        messages_panel = server_view.messages_panel()
+
+        if result.context_id:
+            self.state.current_context_id = result.context_id
+        self.state.current_task_id = result.continue_task_id
+        self._persist_session_state()
+
+        if result.error is not None:
+            logger.error(
+                "Turn failed for %s: %s", self.server_id, result.error, exc_info=True
+            )
+            messages_panel.add_system_message(f"Error: {result.error!s}")
+            self._refresh_status_badges()
+            return
+
+        response = result.response
+        if response is not None:
             messages_panel.add_agent_message(response)
-
             if isinstance(response, Task):
                 messages_panel.update_task(response)
-                if response.artifacts:
-                    for artifact in response.artifacts:
-                        messages_panel.update_artifact(
-                            artifact,
-                            response_task_id(response) or "",
-                            self.state.current_context_id or "",
-                        )
+                for artifact in response.artifacts or []:
+                    messages_panel.update_artifact(
+                        artifact,
+                        response_task_id(response) or "",
+                        self.state.current_context_id or "",
+                    )
 
-            self._refresh_status_badges()
-
-        except Exception as error:
-            logger.error(
-                "Error sending message from %s: %s",
-                self.server_id,
-                error,
-                exc_info=True,
+        if result.canceled:
+            messages_panel.add_system_message("Canceled.")
+        elif result.awaiting_input:
+            messages_panel.add_system_message(
+                "The agent is waiting for your reply. Your next message "
+                "continues this task."
             )
-            messages_panel.add_system_message(f"Error: {error!s}")
-        finally:
-            if self.is_connected:
-                input_panel.set_waiting(False)
-                input_panel.focus_input()
+        elif result.awaiting_auth:
+            messages_panel.add_system_message(
+                "The agent requires authentication before it can continue. "
+                "Update credentials in the Auth tab, then reply."
+            )
+
+        self._refresh_status_badges()
 
     def _refresh_status_badges(self) -> None:
         server_view = self._try_get_server_view()
@@ -769,23 +861,6 @@ class ServerTab(Container):
             return
         self.state.current_task_id = None
         self._persist_session_state()
-
-    def _is_uncontinuable_task_error(self, error: Exception) -> bool:
-        """Return True when the server rejects continuing the current task."""
-        if not isinstance(error, A2AClientError):
-            return False
-        message = str(error).lower()
-        if "task" in message and (
-            "does not exist" in message or "not found" in message
-        ):
-            return True
-        terminal_markers = (
-            "terminal state",
-            "cannot accept further messages",
-            "already completed",
-            "task is completed",
-        )
-        return any(marker in message for marker in terminal_markers)
 
     def _load_task_into_live_view(self, server_view: ServerView, task: Task) -> None:
         messages_panel = server_view.messages_panel()

--- a/src/a2a_handler/tui/server/tab.py
+++ b/src/a2a_handler/tui/server/tab.py
@@ -786,7 +786,7 @@ class ServerTab(Container):
 
         response = result.response
         if response is not None:
-            messages_panel.add_agent_message(response)
+            messages_panel.add_agent_message(response, result.narration)
             if isinstance(response, Task):
                 messages_panel.update_task(response)
                 for artifact in response.artifacts or []:

--- a/src/a2a_handler/turn.py
+++ b/src/a2a_handler/turn.py
@@ -1,0 +1,321 @@
+"""Driving a single agent turn.
+
+A *turn* is one user message and everything the agent sends back in reply: a
+stream of status changes and artifacts, ending either because the task reached
+a terminal state or because the agent handed control back to the client.
+
+This module owns the protocol semantics of that exchange -- when a turn is
+over, which task a follow-up should continue, and what to do when the server
+refuses to continue a saved task. It has no dependency on any user interface,
+so the CLI, the TUI, and the MCP bridge can all drive a turn the same way and
+the rules stay in one testable place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from enum import Enum
+
+from a2a.client.errors import A2AClientError
+from a2a.types import Artifact, Message, Task
+
+from a2a_handler.common import get_logger
+from a2a_handler.service import (
+    A2AService,
+    StreamEvent,
+    continuation_task_id,
+    response_context_id,
+    response_state,
+    state_is_settled,
+    state_needs_auth,
+    state_needs_input,
+)
+
+logger = get_logger(__name__)
+
+_UNCONTINUABLE_MARKERS = (
+    "terminal state",
+    "cannot accept further messages",
+    "already completed",
+    "task is completed",
+)
+
+
+def is_uncontinuable_task_error(error: Exception) -> bool:
+    """Return whether the server refused to continue the referenced task.
+
+    Servers phrase this differently, so this matches on the shapes seen in
+    practice rather than an error code the protocol does not define.
+    """
+    if not isinstance(error, A2AClientError):
+        return False
+    message = str(error).lower()
+    if "task" in message and ("does not exist" in message or "not found" in message):
+        return True
+    return any(marker in message for marker in _UNCONTINUABLE_MARKERS)
+
+
+class TurnEventKind(str, Enum):
+    """What a consumer needs to react to while a turn is in flight."""
+
+    STATUS = "status"
+    ARTIFACT = "artifact"
+    MESSAGE = "message"
+    NOTICE = "notice"
+
+
+@dataclass(frozen=True, slots=True)
+class TurnEvent:
+    """Something worth showing the user while the turn is still running."""
+
+    kind: TurnEventKind
+    state: int | None = None
+    task: Task | None = None
+    artifact: Artifact | None = None
+    message: Message | None = None
+    text: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class TurnResult:
+    """How a turn ended and what the client should do next."""
+
+    response: Task | Message | None = None
+    state: int | None = None
+    context_id: str | None = None
+    continue_task_id: str | None = None
+    awaiting_input: bool = False
+    awaiting_auth: bool = False
+    canceled: bool = False
+    error: Exception | None = None
+
+    @property
+    def failed(self) -> bool:
+        """Return whether the turn ended because of a client-side error."""
+        return self.error is not None
+
+
+@dataclass(slots=True)
+class AgentTurn:
+    """One user message and the agent's streamed reply.
+
+    Iterate :meth:`events` to drive the turn; read :attr:`result` once the
+    iteration finishes. Call :meth:`request_cancel` from another task to ask
+    the agent to stop.
+    """
+
+    service: A2AService
+    text: str
+    context_id: str | None = None
+    task_id: str | None = None
+
+    result: TurnResult | None = None
+    _task_id_seen: str | None = field(default=None, init=False)
+    _cancel_requested: bool = field(default=False, init=False)
+
+    @property
+    def active_task_id(self) -> str | None:
+        """Return the task ID the agent reported for this turn, once known."""
+        return self._task_id_seen
+
+    async def request_cancel(self) -> bool:
+        """Ask the agent to cancel this turn's task.
+
+        Returns whether a cancel was actually sent. A turn that has not yet
+        been assigned a task ID has nothing to cancel protocol-side; the
+        caller should still stop consuming the stream.
+        """
+        self._cancel_requested = True
+        task_id = self._task_id_seen
+        if not task_id:
+            logger.info("Cancel requested before a task ID was known")
+            return False
+        try:
+            await self.service.cancel_task(task_id)
+        except Exception as error:  # noqa: BLE001 - surfaced to the user, not raised
+            logger.warning("Cancel request for task %s failed: %s", task_id, error)
+            return False
+        logger.info("Cancel requested for task %s", task_id)
+        return True
+
+    async def events(self) -> AsyncIterator[TurnEvent]:
+        """Run the turn, yielding events until it settles."""
+        try:
+            async for event in self._stream_with_retry():
+                yield event
+        except asyncio.CancelledError:
+            self.result = TurnResult(
+                context_id=self.context_id,
+                continue_task_id=self._task_id_seen,
+                canceled=True,
+            )
+            raise
+        except Exception as error:  # noqa: BLE001 - reported as a result, not raised
+            logger.error("Turn failed: %s", error, exc_info=True)
+            self.result = TurnResult(
+                context_id=self.context_id,
+                continue_task_id=self.task_id,
+                error=error,
+            )
+
+    async def _stream_with_retry(self) -> AsyncIterator[TurnEvent]:
+        """Stream the turn, retrying once without a task ID if the server balks.
+
+        A saved task can go stale between sessions. Rather than failing the
+        message, drop the task reference and retry within the same context --
+        the conversation continues, only the task thread restarts.
+        """
+        try:
+            async for event in self._stream(self.task_id):
+                yield event
+            return
+        except Exception as error:  # noqa: BLE001 - inspected, then re-raised
+            if not (self.task_id and is_uncontinuable_task_error(error)):
+                raise
+            logger.info("Retrying turn without stale task_id %s", self.task_id)
+
+        yield TurnEvent(
+            kind=TurnEventKind.NOTICE,
+            text=(
+                "The saved task can no longer accept messages. "
+                "Continuing with the saved conversation only."
+            ),
+        )
+        self.task_id = None
+        async for event in self._stream(None):
+            yield event
+
+    async def _stream(self, task_id: str | None) -> AsyncIterator[TurnEvent]:
+        """Consume one streaming attempt and translate it into turn events."""
+        latest: Task | Message | None = None
+        latest_state: int | None = None
+
+        async for event in self.service.stream(
+            self.text,
+            context_id=self.context_id,
+            task_id=task_id,
+        ):
+            if event.task_id:
+                self._task_id_seen = event.task_id
+            if event.context_id:
+                self.context_id = event.context_id
+
+            for turn_event in self._translate(event):
+                yield turn_event
+
+            if event.task is not None:
+                latest = event.task
+            elif event.message is not None:
+                latest = event.message
+
+            if event.state is not None:
+                latest_state = event.state
+                if state_is_settled(event.state):
+                    break
+
+            # A cancel that the agent has acknowledged arrives as a CANCELED
+            # status and settles above. This covers the agent that keeps
+            # streaming regardless: stop consuming rather than ignore the user.
+            if self._cancel_requested:
+                logger.info("Stopping turn consumption after cancel request")
+                break
+
+        self.result = self._settle(latest, latest_state)
+
+    def _translate(self, event: StreamEvent) -> list[TurnEvent]:
+        """Translate one SDK stream event into zero or more turn events.
+
+        Dispatches on ``event_type`` rather than on which fields are populated:
+        every event carries the running task aggregate, so a field-presence
+        check would report a status change on every artifact chunk.
+        """
+        if event.event_type == "artifact":
+            update = event.artifact
+            if update is None or not update.HasField("artifact"):
+                return []
+            return [
+                TurnEvent(
+                    kind=TurnEventKind.ARTIFACT,
+                    artifact=update.artifact,
+                    task=event.task,
+                    state=event.state,
+                    text=event.text,
+                )
+            ]
+
+        if event.event_type == "message":
+            return [
+                TurnEvent(
+                    kind=TurnEventKind.MESSAGE,
+                    message=event.message,
+                    text=event.text,
+                )
+            ]
+
+        # "task" and "status" both describe where the task now stands.
+        return [
+            TurnEvent(
+                kind=TurnEventKind.STATUS,
+                state=event.state,
+                task=event.task,
+                text=event.text,
+            )
+        ]
+
+    def _settle(
+        self,
+        response: Task | Message | None,
+        fallback_state: int | None,
+    ) -> TurnResult:
+        """Build the result describing how this turn ended."""
+        if response is None:
+            return TurnResult(
+                state=fallback_state,
+                context_id=self.context_id,
+                continue_task_id=self._task_id_seen,
+                canceled=self._cancel_requested,
+            )
+
+        state = response_state(response) or fallback_state
+        return TurnResult(
+            response=response,
+            state=state,
+            context_id=response_context_id(response) or self.context_id,
+            continue_task_id=(
+                continuation_task_id(response) or self._continue_from(state)
+            ),
+            awaiting_input=state_needs_input(state),
+            awaiting_auth=state_needs_auth(state),
+            canceled=self._cancel_requested,
+        )
+
+    def _continue_from(self, state: int | None) -> str | None:
+        """Fall back to the observed task ID when the task is still open."""
+        if state_is_settled(state) and not state_needs_input(state):
+            return None
+        return self._task_id_seen
+
+
+def summarize_result(result: TurnResult) -> str:
+    """Return a short line describing an ended turn, for logs and notices."""
+    if result.error is not None:
+        return f"failed: {result.error}"
+    if result.canceled:
+        return "canceled"
+    if result.awaiting_input:
+        return "waiting for your reply"
+    if result.awaiting_auth:
+        return "waiting for authentication"
+    return "done"
+
+
+__all__ = [
+    "AgentTurn",
+    "TurnEvent",
+    "TurnEventKind",
+    "TurnResult",
+    "is_uncontinuable_task_error",
+    "summarize_result",
+]

--- a/src/a2a_handler/turn.py
+++ b/src/a2a_handler/turn.py
@@ -90,6 +90,11 @@ class TurnResult:
     awaiting_auth: bool = False
     canceled: bool = False
     error: Exception | None = None
+    #: The last thing the agent said while the turn was running. A turn that
+    #: is canceled or interrupted often leaves no text on the task itself, so
+    #: this is what the user has to go on -- without it a stopped task reads
+    #: as "no text in response" right after they watched it narrate.
+    narration: str = ""
 
     @property
     def failed(self) -> bool:
@@ -114,6 +119,7 @@ class AgentTurn:
     result: TurnResult | None = None
     _task_id_seen: str | None = field(default=None, init=False)
     _cancel_requested: bool = field(default=False, init=False)
+    _last_narration: str = field(default="", init=False)
 
     @property
     def active_task_id(self) -> str | None:
@@ -150,6 +156,7 @@ class AgentTurn:
                 context_id=self.context_id,
                 continue_task_id=self._task_id_seen,
                 canceled=True,
+                narration=self._last_narration,
             )
             raise
         except Exception as error:  # noqa: BLE001 - reported as a result, not raised
@@ -201,6 +208,9 @@ class AgentTurn:
                 self._task_id_seen = event.task_id
             if event.context_id:
                 self.context_id = event.context_id
+
+            if event.text:
+                self._last_narration = event.text
 
             for turn_event in self._translate(event):
                 yield turn_event
@@ -276,6 +286,7 @@ class AgentTurn:
                 context_id=self.context_id,
                 continue_task_id=self._task_id_seen,
                 canceled=self._cancel_requested,
+                narration=self._last_narration,
             )
 
         state = response_state(response) or fallback_state
@@ -289,6 +300,7 @@ class AgentTurn:
             awaiting_input=state_needs_input(state),
             awaiting_auth=state_needs_auth(state),
             canceled=self._cancel_requested,
+            narration=self._last_narration,
         )
 
     def _continue_from(self, state: int | None) -> str | None:

--- a/tests/core/test_turn.py
+++ b/tests/core/test_turn.py
@@ -356,3 +356,44 @@ class TestStandaloneMessage:
         assert turn.result is not None
         assert turn.result.response is message
         assert turn.result.failed is False
+
+
+class TestStatusMessageFallback:
+    """A task whose only text is on its status message."""
+
+    async def test_paused_task_text_comes_from_the_status_message(self):
+        """An agent asking a question often carries it only on the status."""
+        from a2a.types import TaskStatus
+
+        from a2a_handler.service import extract_text_from_task
+
+        task = make_task(state=TaskState.TASK_STATE_INPUT_REQUIRED)
+        task.ClearField("artifacts")
+        task.ClearField("history")
+        task.status.CopyFrom(
+            TaskStatus(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                message=make_message(text="Which region?"),
+            )
+        )
+
+        assert extract_text_from_task(task) == "Which region?"
+
+    async def test_artifacts_still_win_over_the_status_message(self):
+        """The fallback must not displace the task's real output."""
+        from a2a.types import TaskStatus
+
+        from a2a_handler.service import extract_text_from_task
+
+        task = make_task(
+            state=TaskState.TASK_STATE_COMPLETED,
+            artifacts=[make_artifact(text="the real answer")],
+        )
+        task.status.CopyFrom(
+            TaskStatus(
+                state=TaskState.TASK_STATE_COMPLETED,
+                message=make_message(text="incidental narration"),
+            )
+        )
+
+        assert extract_text_from_task(task) == "the real answer"

--- a/tests/core/test_turn.py
+++ b/tests/core/test_turn.py
@@ -1,0 +1,358 @@
+"""Tests for driving a single agent turn."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Sequence
+from unittest.mock import AsyncMock
+
+import pytest
+from a2a.client.errors import A2AClientError
+from a2a.types import TaskState
+
+from a2a_handler.service import StreamEvent
+from a2a_handler.turn import (
+    AgentTurn,
+    TurnEventKind,
+    is_uncontinuable_task_error,
+    summarize_result,
+)
+from tests.factories import (
+    make_artifact,
+    make_artifact_update_event,
+    make_message,
+    make_status_update_event,
+    make_task,
+)
+
+TASK_ID = "task-123"
+CTX_ID = "ctx-123"
+
+
+def _status_event(state: TaskState, text: str = "") -> StreamEvent:
+    """Build a Handler stream event carrying a status change."""
+    task = make_task(state=state, task_id=TASK_ID, context_id=CTX_ID)
+    return StreamEvent(
+        event_type="status",
+        task=task,
+        status=make_status_update_event(
+            task_id=TASK_ID, context_id=CTX_ID, state=state
+        ),
+        text=text,
+    )
+
+
+def _artifact_event(artifact_id: str = "artifact-1") -> StreamEvent:
+    """Build a Handler stream event carrying an artifact update."""
+    artifact = make_artifact(artifact_id=artifact_id)
+    return StreamEvent(
+        event_type="artifact",
+        task=make_task(
+            state=TaskState.TASK_STATE_WORKING, task_id=TASK_ID, context_id=CTX_ID
+        ),
+        artifact=make_artifact_update_event(
+            task_id=TASK_ID, context_id=CTX_ID, artifact=artifact
+        ),
+        text="Artifact body text",
+    )
+
+
+def _service_streaming(
+    events: Sequence[StreamEvent],
+    *,
+    fail_first_with: Exception | None = None,
+) -> AsyncMock:
+    """Build a service double whose ``stream`` replays the given events.
+
+    When ``fail_first_with`` is set the first call raises it, letting tests
+    exercise the retry path.
+    """
+    service = AsyncMock()
+    calls: list[str | None] = []
+
+    def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+        calls.append(task_id)
+
+        async def gen() -> AsyncIterator[StreamEvent]:
+            if fail_first_with is not None and len(calls) == 1:
+                raise fail_first_with
+            for event in events:
+                yield event
+
+        return gen()
+
+    service.stream = stream
+    service.stream_calls = calls
+    return service
+
+
+async def _drain(turn: AgentTurn) -> list:
+    """Consume a turn's events into a list."""
+    return [event async for event in turn.events()]
+
+
+class TestTurnCompletion:
+    """A turn that runs to a terminal state."""
+
+    async def test_yields_status_and_artifact_events(self):
+        service = _service_streaming(
+            [
+                _status_event(TaskState.TASK_STATE_WORKING, "thinking"),
+                _artifact_event(),
+                _status_event(TaskState.TASK_STATE_COMPLETED, "done"),
+            ]
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        events = await _drain(turn)
+
+        kinds = [event.kind for event in events]
+        assert kinds == [
+            TurnEventKind.STATUS,
+            TurnEventKind.ARTIFACT,
+            TurnEventKind.STATUS,
+        ]
+        assert events[1].artifact is not None
+        assert events[1].artifact.artifact_id == "artifact-1"
+
+    async def test_result_reports_completion_and_clears_task(self):
+        service = _service_streaming([_status_event(TaskState.TASK_STATE_COMPLETED)])
+        turn = AgentTurn(service=service, text="hi")
+
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.state == TaskState.TASK_STATE_COMPLETED
+        assert turn.result.context_id == CTX_ID
+        # A completed task cannot take more messages.
+        assert turn.result.continue_task_id is None
+        assert turn.result.awaiting_input is False
+        assert turn.result.failed is False
+
+    async def test_stops_at_terminal_state_without_draining_rest(self):
+        """A settled state ends the turn even if the server keeps talking."""
+        service = _service_streaming(
+            [
+                _status_event(TaskState.TASK_STATE_COMPLETED),
+                _status_event(TaskState.TASK_STATE_WORKING),
+            ]
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        events = await _drain(turn)
+
+        assert len(events) == 1
+        assert turn.result is not None
+        assert turn.result.state == TaskState.TASK_STATE_COMPLETED
+
+
+class TestInputRequired:
+    """The state that previously hung the client."""
+
+    async def test_input_required_settles_the_turn(self):
+        service = _service_streaming(
+            [
+                _status_event(TaskState.TASK_STATE_WORKING),
+                _status_event(TaskState.TASK_STATE_INPUT_REQUIRED, "Which region?"),
+            ]
+        )
+        turn = AgentTurn(service=service, text="deploy")
+
+        events = await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.awaiting_input is True
+        assert events[-1].text == "Which region?"
+
+    async def test_input_required_keeps_the_task_for_the_reply(self):
+        """The follow-up must continue the same task, not start a new one."""
+        service = _service_streaming(
+            [_status_event(TaskState.TASK_STATE_INPUT_REQUIRED)]
+        )
+        turn = AgentTurn(service=service, text="deploy")
+
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.continue_task_id == TASK_ID
+
+    async def test_auth_required_settles_and_flags(self):
+        service = _service_streaming(
+            [_status_event(TaskState.TASK_STATE_AUTH_REQUIRED)]
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.awaiting_auth is True
+        assert turn.result.continue_task_id == TASK_ID
+
+
+class TestStaleTaskRetry:
+    """A saved task that the server will no longer continue."""
+
+    async def test_retries_without_task_id_and_notices(self):
+        service = _service_streaming(
+            [_status_event(TaskState.TASK_STATE_COMPLETED)],
+            fail_first_with=A2AClientError("Task task-999 does not exist"),
+        )
+        turn = AgentTurn(service=service, text="hi", task_id="task-999")
+
+        events = await _drain(turn)
+
+        assert service.stream_calls == ["task-999", None]
+        assert events[0].kind == TurnEventKind.NOTICE
+        assert "saved task" in events[0].text.lower()
+        assert turn.result is not None
+        assert turn.result.failed is False
+
+    async def test_other_errors_are_not_retried(self):
+        service = _service_streaming(
+            [], fail_first_with=A2AClientError("upstream exploded")
+        )
+        turn = AgentTurn(service=service, text="hi", task_id="task-999")
+
+        await _drain(turn)
+
+        assert service.stream_calls == ["task-999"]
+        assert turn.result is not None
+        assert turn.result.failed is True
+
+    async def test_no_retry_when_there_was_no_task_id(self):
+        service = _service_streaming(
+            [], fail_first_with=A2AClientError("Task not found")
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        await _drain(turn)
+
+        assert service.stream_calls == [None]
+        assert turn.result is not None
+        assert turn.result.failed is True
+
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Task task-1 does not exist", True),
+            ("task not found", True),
+            ("Task is in a terminal state", True),
+            ("cannot accept further messages", True),
+            ("rate limited", False),
+            ("connection reset", False),
+        ],
+    )
+    def test_uncontinuable_error_detection(self, message, expected):
+        assert is_uncontinuable_task_error(A2AClientError(message)) is expected
+
+    def test_non_a2a_errors_are_never_uncontinuable(self):
+        assert is_uncontinuable_task_error(ValueError("task not found")) is False
+
+
+class TestCancel:
+    """Protocol-level cancellation."""
+
+    async def test_request_cancel_calls_the_service(self):
+        service = _service_streaming([_status_event(TaskState.TASK_STATE_WORKING)])
+        turn = AgentTurn(service=service, text="hi")
+        await _drain(turn)
+
+        sent = await turn.request_cancel()
+
+        assert sent is True
+        service.cancel_task.assert_awaited_once_with(TASK_ID)
+
+    async def test_cancel_before_task_id_is_known_sends_nothing(self):
+        service = _service_streaming([])
+        turn = AgentTurn(service=service, text="hi")
+
+        sent = await turn.request_cancel()
+
+        assert sent is False
+        service.cancel_task.assert_not_awaited()
+
+    async def test_cancel_failure_is_reported_not_raised(self):
+        service = _service_streaming([_status_event(TaskState.TASK_STATE_WORKING)])
+        service.cancel_task.side_effect = A2AClientError("not cancelable")
+        turn = AgentTurn(service=service, text="hi")
+        await _drain(turn)
+
+        sent = await turn.request_cancel()
+
+        assert sent is False
+
+    async def test_worker_cancellation_records_a_canceled_result(self):
+        """Cancelling the consuming task still leaves a usable result."""
+        started = asyncio.Event()
+
+        def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+            async def gen() -> AsyncIterator[StreamEvent]:
+                yield _status_event(TaskState.TASK_STATE_WORKING)
+                started.set()
+                await asyncio.sleep(30)
+
+            return gen()
+
+        service = AsyncMock()
+        service.stream = stream
+        turn = AgentTurn(service=service, text="hi")
+
+        async def consume() -> None:
+            async for _ in turn.events():
+                pass
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert turn.result is not None
+        assert turn.result.canceled is True
+        assert turn.result.continue_task_id == TASK_ID
+
+
+class TestSummarize:
+    """The one-line description used for notices and logs."""
+
+    @pytest.mark.parametrize(
+        "state,expected",
+        [
+            (TaskState.TASK_STATE_COMPLETED, "done"),
+            (TaskState.TASK_STATE_INPUT_REQUIRED, "waiting for your reply"),
+            (TaskState.TASK_STATE_AUTH_REQUIRED, "waiting for authentication"),
+        ],
+    )
+    async def test_summaries(self, state, expected):
+        service = _service_streaming([_status_event(state)])
+        turn = AgentTurn(service=service, text="hi")
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert summarize_result(turn.result) == expected
+
+    async def test_error_summary_includes_the_cause(self):
+        service = _service_streaming([], fail_first_with=A2AClientError("boom"))
+        turn = AgentTurn(service=service, text="hi")
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert "boom" in summarize_result(turn.result)
+
+
+class TestStandaloneMessage:
+    """Agents may reply with a Message instead of a Task."""
+
+    async def test_message_only_reply_settles(self):
+        message = make_message(text="hello back", context_id=CTX_ID)
+        service = _service_streaming(
+            [StreamEvent(event_type="message", message=message, text="hello back")]
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        events = await _drain(turn)
+
+        assert events[0].kind == TurnEventKind.MESSAGE
+        assert turn.result is not None
+        assert turn.result.response is message
+        assert turn.result.failed is False

--- a/tests/core/test_turn.py
+++ b/tests/core/test_turn.py
@@ -397,3 +397,66 @@ class TestStatusMessageFallback:
         )
 
         assert extract_text_from_task(task) == "the real answer"
+
+
+class TestNarration:
+    """What the agent last said, kept for turns that end with no text."""
+
+    async def test_narration_survives_a_cancel(self):
+        """A canceled task carries no text; the user should still see progress."""
+        service = _service_streaming(
+            [
+                _status_event(TaskState.TASK_STATE_WORKING, "Working... step 4 of 40"),
+                _status_event(TaskState.TASK_STATE_CANCELED),
+            ]
+        )
+        turn = AgentTurn(service=service, text="slow")
+
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.narration == "Working... step 4 of 40"
+
+    async def test_narration_tracks_the_latest_text(self):
+        service = _service_streaming(
+            [
+                _status_event(TaskState.TASK_STATE_WORKING, "first"),
+                _status_event(TaskState.TASK_STATE_WORKING, "second"),
+                _status_event(TaskState.TASK_STATE_COMPLETED, "third"),
+            ]
+        )
+        turn = AgentTurn(service=service, text="hi")
+
+        await _drain(turn)
+
+        assert turn.result is not None
+        assert turn.result.narration == "third"
+
+    async def test_narration_survives_worker_cancellation(self):
+        """Cancelling the consumer keeps whatever the agent had already said."""
+        started = asyncio.Event()
+
+        def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+            async def gen() -> AsyncIterator[StreamEvent]:
+                yield _status_event(TaskState.TASK_STATE_WORKING, "halfway there")
+                started.set()
+                await asyncio.sleep(30)
+
+            return gen()
+
+        service = AsyncMock()
+        service.stream = stream
+        turn = AgentTurn(service=service, text="slow")
+
+        async def consume() -> None:
+            async for _ in turn.events():
+                pass
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert turn.result is not None
+        assert turn.result.narration == "halfway there"

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -2268,3 +2268,80 @@ async def test_cancel_button_stops_the_turn_and_asks_the_agent() -> None:
             assert not workspace.query("#streaming-message")
             texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
             assert any("canceled" in text.lower() for text in texts)
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_any_text_says_so_plainly() -> None:
+    """A turn stopped before the agent spoke must not claim there was no response."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    # A task exists (so there is something to cancel) but the agent has not
+    # said anything yet -- the window the screenshot caught.
+    silent = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_WORKING,
+            task_id="task-silent",
+            context_id="ctx-silent",
+        ),
+    )
+    canceled = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_CANCELED,
+            task_id="task-silent",
+            context_id="ctx-silent",
+        ),
+    )
+
+    def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+        async def events():
+            yield silent
+            started.set()
+            await release.wait()
+            yield canceled
+
+        return events()
+
+    catalog_patch, client_patch, service_patch = _connected_workspace_patches(
+        repo_connection, make_agent_card(name="Demo Agent"), AsyncMock()
+    )
+    with catalog_patch, client_patch, service_patch as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = make_agent_card(name="Demo Agent")
+        mock_service.stream = stream
+        mock_service.cancel_task.side_effect = lambda _tid: release.set()
+        mock_service.set_credentials = Mock()
+        mock_service.clear_credentials = Mock()
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            workspace.query_one("#message-input", Input).value = "go"
+            workspace.handle_send_button()
+            await pilot.pause()
+            await asyncio.wait_for(started.wait(), timeout=2)
+            await pilot.pause()
+
+            await workspace.cancel_active_turn()
+            for _ in range(40):
+                await pilot.pause()
+                if not workspace.query_one("#message-input", Input).disabled:
+                    break
+            await pilot.pause()
+
+            texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert not any("no text in response" in t for t in texts), texts
+            assert any("stopped before the agent replied" in t for t in texts), texts

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -19,6 +19,7 @@ from textual.widgets import Button, HelpPanel, Input, Select, Static, Tab, Tabs
 
 from a2a_handler import __version__
 from a2a_handler.auth import AuthType, create_bearer_auth
+from a2a_handler.service import StreamEvent, extract_text
 from a2a_handler.servers import (
     ServerAuthConfig,
     ServerCatalog,
@@ -29,9 +30,10 @@ from a2a_handler.session import AgentSession
 from a2a_handler.tui import HandlerTUI
 from a2a_handler.tui.app import HandlerTUI as HandlerTUIApplication
 from a2a_handler.tui.components import AgentCardPanel, TabbedMessagesPanel
+from a2a_handler.tui.components.messages import StreamingMessage
 from a2a_handler.tui.server.tabs import ServerTabs
 from a2a_handler.tui.server.views import ConnectionBar, ServerView
-from tests.factories import make_agent_card
+from tests.factories import make_agent_card, make_artifact, make_task
 
 
 def _chat_texts(messages_panel: TabbedMessagesPanel) -> list[str]:
@@ -54,6 +56,60 @@ def _make_server(
         auth=auth,
         origin_label=source.value.capitalize(),
     )
+
+
+_Reply = Message | Task | StreamEvent
+_TurnPayload = _Reply | BaseException
+
+
+def _reply_events(response: _Reply) -> list[StreamEvent]:
+    """Build the stream a server sends for a single, immediate reply.
+
+    Accepts a ready-made ``StreamEvent`` unchanged, so tests can describe a
+    specific state without restating the whole event.
+    """
+    if isinstance(response, StreamEvent):
+        return [response]
+    if isinstance(response, Task):
+        return [
+            StreamEvent(
+                event_type="status",
+                task=response,
+                text=extract_text(response),
+            )
+        ]
+    return [
+        StreamEvent(
+            event_type="message",
+            message=response,
+            text=extract_text(response),
+        )
+    ]
+
+
+def _stub_stream(mock_service: AsyncMock, turns: list[_TurnPayload]) -> list[object]:
+    """Replay one payload per ``stream`` call, recording the call arguments.
+
+    Each entry in ``turns`` is either an exception to raise or a response to
+    deliver as a stream. Returns the list that accumulates the calls, so tests
+    can assert on them the way they used to assert on ``send``.
+    """
+    calls: list[object] = []
+
+    def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001
+        calls.append(call(text, context_id=context_id, task_id=task_id))
+        payload = turns[min(len(calls) - 1, len(turns) - 1)]
+
+        async def events():
+            if isinstance(payload, BaseException):
+                raise payload
+            for event in _reply_events(payload):
+                yield event
+
+        return events()
+
+    mock_service.stream = stream
+    return calls
 
 
 def _missing_task_error(task_id: str) -> A2AClientError:
@@ -993,10 +1049,10 @@ async def test_send_retries_without_stale_task_id(
     ):
         mock_service = AsyncMock()
         mock_service.get_card.return_value = mock_card
-        mock_service.send.side_effect = [
-            _missing_task_error("task-stale-1"),
-            response_message,
-        ]
+        stream_calls = _stub_stream(
+            mock_service,
+            [_missing_task_error("task-stale-1"), response_message],
+        )
         mock_service.set_credentials = Mock()
         mock_service.clear_credentials = Mock()
         mock_service_cls.return_value = mock_service
@@ -1018,7 +1074,7 @@ async def test_send_retries_without_stale_task_id(
             workspace.handle_send_button()
             await pilot.pause()
 
-            assert mock_service.send.await_args_list == [
+            assert stream_calls == [
                 call(
                     "Hello again",
                     context_id="ctx-saved-123456",
@@ -1040,7 +1096,8 @@ async def test_send_retries_without_stale_task_id(
             messages_panel = workspace.query_one(TabbedMessagesPanel)
             texts = _chat_texts(messages_panel)
             assert any(
-                "retrying with the saved context only" in text.lower() for text in texts
+                "continuing with the saved conversation only" in text.lower()
+                for text in texts
             )
             assert any("Recovered response" in text for text in texts)
 
@@ -1079,10 +1136,10 @@ async def test_send_retries_without_completed_task_id(
     ):
         mock_service = AsyncMock()
         mock_service.get_card.return_value = mock_card
-        mock_service.send.side_effect = [
-            _completed_task_error("task-completed-1"),
-            response_message,
-        ]
+        stream_calls = _stub_stream(
+            mock_service,
+            [_completed_task_error("task-completed-1"), response_message],
+        )
         mock_service.set_credentials = Mock()
         mock_service.clear_credentials = Mock()
         mock_service_cls.return_value = mock_service
@@ -1104,7 +1161,7 @@ async def test_send_retries_without_completed_task_id(
             workspace.handle_send_button()
             await pilot.pause()
 
-            assert mock_service.send.await_args_list == [
+            assert stream_calls == [
                 call(
                     "Hello again",
                     context_id="ctx-saved-123456",
@@ -1126,7 +1183,8 @@ async def test_send_retries_without_completed_task_id(
             messages_panel = workspace.query_one(TabbedMessagesPanel)
             texts = _chat_texts(messages_panel)
             assert any(
-                "retrying with the saved context only" in text.lower() for text in texts
+                "continuing with the saved conversation only" in text.lower()
+                for text in texts
             )
             assert any("Recovered from terminal task" in text for text in texts)
 
@@ -1724,7 +1782,7 @@ async def test_send_button_submits_typed_message_through_ui() -> None:
     ):
         mock_service = AsyncMock()
         mock_service.get_card.return_value = mock_card
-        mock_service.send.return_value = response_message
+        stream_calls = _stub_stream(mock_service, [response_message])
         mock_service.set_credentials = Mock()
         mock_service.clear_credentials = Mock()
         mock_service_cls.return_value = mock_service
@@ -1758,11 +1816,9 @@ async def test_send_button_submits_typed_message_through_ui() -> None:
             await pilot.click("#send-btn")
             await pilot.pause()
 
-            mock_service.send.assert_awaited_once_with(
-                "Hello agent",
-                context_id=initial_context_id,
-                task_id=None,
-            )
+            assert stream_calls == [
+                call("Hello agent", context_id=initial_context_id, task_id=None)
+            ]
             assert workspace.query_one("#message-input", Input).value == ""
             assert workspace.state.current_context_id == "ctx-response"
             assert workspace.state.current_task_id == "task-response"
@@ -1793,10 +1849,14 @@ async def test_send_shows_loading_indicator_while_waiting_for_response() -> None
     send_started = asyncio.Event()
     release_response = asyncio.Event()
 
-    async def slow_send(*args, **kwargs):
-        send_started.set()
-        await release_response.wait()
-        return response_message
+    def slow_stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+        async def events():
+            send_started.set()
+            await release_response.wait()
+            for event in _reply_events(response_message):
+                yield event
+
+        return events()
 
     with (
         patch(
@@ -1811,7 +1871,7 @@ async def test_send_shows_loading_indicator_while_waiting_for_response() -> None
     ):
         mock_service = AsyncMock()
         mock_service.get_card.return_value = mock_card
-        mock_service.send.side_effect = slow_send
+        mock_service.stream = slow_stream
         mock_service.set_credentials = Mock()
         mock_service.clear_credentials = Mock()
         mock_service_cls.return_value = mock_service
@@ -1902,7 +1962,7 @@ async def test_terminal_task_response_is_not_reused_for_follow_up_messages(
     ):
         mock_service = AsyncMock()
         mock_service.get_card.return_value = mock_card
-        mock_service.send.side_effect = [first_response, second_response]
+        stream_calls = _stub_stream(mock_service, [first_response, second_response])
         mock_service.set_credentials = Mock()
         mock_service.clear_credentials = Mock()
         mock_service_cls.return_value = mock_service
@@ -1935,7 +1995,7 @@ async def test_terminal_task_response_is_not_reused_for_follow_up_messages(
             workspace.handle_send_button()
             await pilot.pause()
 
-            assert mock_service.send.await_args_list == [
+            assert stream_calls == [
                 call(
                     "Hello once",
                     context_id=initial_context_id,
@@ -1950,7 +2010,8 @@ async def test_terminal_task_response_is_not_reused_for_follow_up_messages(
 
             texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
             assert not any(
-                "retrying with the saved context only" in text.lower() for text in texts
+                "continuing with the saved conversation only" in text.lower()
+                for text in texts
             )
 
 
@@ -1977,3 +2038,233 @@ async def test_close_server_action_removes_active_server_tab() -> None:
         active_server = app.query_one(ServerTabs).get_active_server()
         assert active_server is not None
         assert active_server.server_id == "server-1"
+
+
+def _connected_workspace_patches(repo_connection, mock_card, new_http_client):
+    """Patch set that puts a workspace one click away from being connected."""
+    return (
+        patch(
+            "a2a_handler.tui.server.tab.load_server_catalog",
+            return_value=ServerCatalog(repository_servers=(repo_connection,)),
+        ),
+        patch(
+            "a2a_handler.tui.server.tab.build_http_client",
+            return_value=new_http_client,
+        ),
+        patch("a2a_handler.tui.server.tab.A2AService"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_updates_render_before_the_turn_finishes() -> None:
+    """Intermediate status and artifact events should appear while streaming."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    release = asyncio.Event()
+    streaming_started = asyncio.Event()
+
+    working = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_WORKING,
+            task_id="task-stream",
+            context_id="ctx-stream",
+        ),
+        text="Looking things up",
+    )
+    done = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_COMPLETED,
+            task_id="task-stream",
+            context_id="ctx-stream",
+            artifacts=[make_artifact(text="All set")],
+        ),
+        text="Finishing up",
+    )
+
+    def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+        async def events():
+            yield working
+            streaming_started.set()
+            await release.wait()
+            yield done
+
+        return events()
+
+    catalog_patch, client_patch, service_patch = _connected_workspace_patches(
+        repo_connection, make_agent_card(name="Demo Agent"), AsyncMock()
+    )
+    with catalog_patch, client_patch, service_patch as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = make_agent_card(name="Demo Agent")
+        mock_service.stream = stream
+        mock_service.set_credentials = Mock()
+        mock_service.clear_credentials = Mock()
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            workspace.query_one("#message-input", Input).value = "Do the thing"
+            workspace.handle_send_button()
+            await pilot.pause()
+            await asyncio.wait_for(streaming_started.wait(), timeout=2)
+            await pilot.pause()
+
+            # Mid-turn: a live reply is mounted and shows the agent's progress.
+            live = workspace.query_one("#streaming-message", StreamingMessage)
+            assert "Looking things up" in live.body_text
+            label = workspace.query_one("#send-loading-label", Static)
+            assert "working" in str(label.content)
+            # The stop control is offered while the turn is in flight.
+            assert not workspace.query_one("#cancel-btn", Button).has_class("hidden")
+
+            release.set()
+            await pilot.pause()
+            await pilot.pause()
+
+            # After the turn: live widget gone, final message rendered.
+            assert not workspace.query("#streaming-message")
+            assert workspace.query_one("#cancel-btn", Button).has_class("hidden")
+            texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any("All set" in text for text in texts)
+
+
+@pytest.mark.asyncio
+async def test_input_required_prompts_for_a_reply_and_keeps_the_task(
+    patch_server_sources: Mock,
+) -> None:
+    """An agent asking a question should unblock input and keep the task."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    asking = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_INPUT_REQUIRED,
+            task_id="task-ask",
+            context_id="ctx-ask",
+        ),
+        text="Which region should I deploy to?",
+    )
+
+    catalog_patch, client_patch, service_patch = _connected_workspace_patches(
+        repo_connection, make_agent_card(name="Demo Agent"), AsyncMock()
+    )
+    with catalog_patch, client_patch, service_patch as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = make_agent_card(name="Demo Agent")
+        stream_calls = _stub_stream(mock_service, [asking])
+        mock_service.set_credentials = Mock()
+        mock_service.clear_credentials = Mock()
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            workspace.query_one("#message-input", Input).value = "deploy"
+            workspace.handle_send_button()
+            await pilot.pause()
+            await pilot.pause()
+
+            message_input = workspace.query_one("#message-input", Input)
+            # The turn ends rather than hanging, and input comes back.
+            assert message_input.disabled is False
+            assert "waiting for your reply" in message_input.placeholder.lower()
+            # The open task is kept so the reply continues it.
+            assert workspace.state.current_task_id == "task-ask"
+
+            texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any("waiting for your reply" in text.lower() for text in texts)
+
+            # The follow-up continues the same task.
+            workspace.query_one("#message-input", Input).value = "us-east-1"
+            workspace.handle_send_button()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert stream_calls[-1] == call(
+                "us-east-1", context_id="ctx-ask", task_id="task-ask"
+            )
+
+
+@pytest.mark.asyncio
+async def test_cancel_button_stops_the_turn_and_asks_the_agent() -> None:
+    """Pressing stop should send a protocol cancel and release the input."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    streaming_started = asyncio.Event()
+
+    working = StreamEvent(
+        event_type="status",
+        task=make_task(
+            state=TaskState.TASK_STATE_WORKING,
+            task_id="task-cancel",
+            context_id="ctx-cancel",
+        ),
+        text="Working on it",
+    )
+
+    def stream(text, *, context_id=None, task_id=None):  # noqa: ANN001, ARG001
+        async def events():
+            yield working
+            streaming_started.set()
+            await asyncio.sleep(30)
+
+        return events()
+
+    catalog_patch, client_patch, service_patch = _connected_workspace_patches(
+        repo_connection, make_agent_card(name="Demo Agent"), AsyncMock()
+    )
+    with catalog_patch, client_patch, service_patch as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = make_agent_card(name="Demo Agent")
+        mock_service.stream = stream
+        mock_service.set_credentials = Mock()
+        mock_service.clear_credentials = Mock()
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            workspace.query_one("#message-input", Input).value = "long job"
+            workspace.handle_send_button()
+            await pilot.pause()
+            await asyncio.wait_for(streaming_started.wait(), timeout=2)
+            await pilot.pause()
+
+            await workspace.cancel_active_turn()
+            await pilot.pause()
+            await pilot.pause()
+
+            # The agent was asked to cancel the actual task.
+            mock_service.cancel_task.assert_awaited_once_with("task-cancel")
+            # The UI is usable again rather than stuck waiting.
+            assert workspace.query_one("#message-input", Input).disabled is False
+            assert not workspace.query("#streaming-message")
+            texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any("canceled" in text.lower() for text in texts)


### PR DESCRIPTION
First step toward A2A parity. The TUI sent a message and blocked until the task finished — it never called `stream()`, `cancel_task()`, or `resubscribe()`. Streaming is A2A's headline capability and the agent card advertises it, but Handler's flagship interface showed nothing until a task completed and offered no way to stop one.

The events were already there. `A2AService.send()` consumed a stream internally and kept only the final event, discarding every `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent` on the way past.

## A turn layer, not a bigger `_send_message`

`_send_message` was ~90 lines mixing widget access, credential syncing, protocol retry logic, state mutation, session persistence, and rendering. Adding streaming there would have made it worse.

Instead this adds **`a2a_handler.turn`**: one user message and the agent's streamed reply, as `AgentTurn` yielding `TurnEvent`s and ending in a `TurnResult`. It owns the protocol semantics of an exchange — when a turn is over, which task a follow-up continues, what to do when a server refuses a stale task — with no dependency on any user interface.

That matters for what's next: the CLI and MCP bridge can adopt the same rules instead of reimplementing them, and the rules stay in one tested place. The stale-task retry moved here out of the widget, where it had been tangled up with rendering. 25 of the 35 new tests are plain async tests with no Textual involved.

## `INPUT_REQUIRED` — a correctness bug, not a missing feature

Nothing in Handler referenced this state. It isn't terminal, so a turn that waits for a terminal state waits forever: an agent that paused to ask a question left the client hanging with the input disabled.

Turns now settle on the interrupted states as well as the terminal ones. The input is released with a prompt explaining the agent is waiting, and the open task is kept so the reply continues it rather than starting a new thread. `AUTH_REQUIRED` settles the same way and points at the Auth tab.

## Cancel

A STOP control appears while a turn is in flight, sends a real `CancelTask`, and releases the input. If the agent can't cancel, that's said plainly rather than left ambiguous. Turns also stop consuming after a cancel request, so an agent that keeps streaming can't hold the UI.

## Rendering

Replies stream into a transient `StreamingMessage` that is replaced by a normal `AgentMessage` once the turn settles, so a finished transcript looks the same whether or not the reply arrived incrementally.

## Verification

450 tests pass (35 new), plus ruff, `ruff format`, and `ty`.

The earlier round of this work could only be checked against an agent advertising `streaming: false`, so the streaming path was covered by tests alone. That gap is now closed with a deterministic streaming agent (kept outside this repo — it needs `google-adk`, which v0.2.0 deliberately removed). Against it:

| Checked | Result |
|---|---|
| CLI `message stream` | 8 events, 4 distinct progress updates arriving separately |
| TUI streaming | Drove the real TUI headlessly; 4 distinct live updates observed as they arrived, final message rendered, transient widget removed, task ID cleared |
| Cancel | Input released 0.29s after STOP — and the **server reports `canceled`** when queried afterward, so it's a real protocol cancel, not a client-side abandon |
| Failure path | Streams a working update, then settles at `TASK_STATE_FAILED` with the reason attached |
| CLI `message send` | Unchanged |

Worth knowing for anyone testing this: ADK's `AgentCardBuilder` defaults to a bare `AgentCapabilities()`, leaving `streaming` false. That's why most ADK agents won't exercise this path — the card has to set it explicitly.

## Coverage

TUI method coverage goes 2/11 → 4/11 (`SendStreamingMessage` and `CancelTask`). `SubscribeToTask` is still unwired in the TUI.

## Not in this PR

Sending non-text parts, `ListTasks`, the two missing push-notification config methods, `GetExtendedAgentCard`, transport negotiation, and the remaining auth schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)