### PR TITLE
feat: list and delete push notification configs

### DIFF
--- a/src/a2a_handler/cli/task.py
+++ b/src/a2a_handler/cli/task.py
@@ -471,6 +471,148 @@ def notification_set(
     asyncio.run(do_set())
 
 
+@task_notification.command("list")
+@click.argument("task_id_arg", metavar="[TASK_ID]", required=False)
+@click.option("--url", "agent_url", help="Agent URL")
+@click.option("--server", "-s", "server_name", help="Named server from servers.toml")
+@click.option("--task", "task_id", help="Task ID (alias for TASK_ID)")
+@click.option(
+    "--page-size",
+    type=int,
+    help="Configs per request page (all pages are still fetched)",
+)
+@click.option(
+    "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
+)
+@click.option(
+    "--api-key-env", "-k", help="Env var containing API key (overrides saved)"
+)
+def notification_list(
+    task_id_arg: Optional[str],
+    agent_url: Optional[str],
+    server_name: Optional[str],
+    task_id: Optional[str],
+    page_size: Optional[int],
+    bearer_env: Optional[str],
+    api_key_env: Optional[str],
+) -> None:
+    """List a task's push notification configs, following pagination to the end.
+
+    \b
+    Examples:
+      $ handler task notification list task-123 --server my_agent
+      $ handler task notification list --server my_agent --task task-123
+      $ handler --output json task notification list task-123 --url http://localhost:8000
+    """
+    output = Output()
+    task_id = require_task_id(resolve_task_id(task_id_arg, task_id))
+
+    selection = resolve_agent_selection(agent_url, server_name)
+    resolved_url = selection.agent_url
+
+    try:
+        validate_agent_url(resolved_url)
+        validate_resource_id(task_id, "task_id")
+    except InputValidationError as error:
+        handle_validation_error(error, output)
+        raise click.Abort() from error
+
+    log.info("Listing push configs for task %s at %s", task_id, resolved_url)
+
+    credentials = resolve_selection_credentials(selection, bearer_env, api_key_env)
+
+    async def do_list() -> None:
+        try:
+            async with build_http_client(credentials=credentials) as http_client:
+                service = A2AService(http_client, resolved_url, credentials=credentials)
+
+                configs = await service.list_all_push_configs(
+                    task_id, page_size=page_size
+                )
+                output.json(
+                    {
+                        "count": len(configs),
+                        "configs": [push_config_dump(config) for config in configs],
+                    }
+                )
+
+        except Exception as e:
+            handle_client_error(e, resolved_url, output)
+            raise click.Abort()
+
+    asyncio.run(do_list())
+
+
+@task_notification.command("remove")
+@click.argument("task_id_arg", metavar="[TASK_ID]", required=False)
+@click.option("--url", "agent_url", help="Agent URL")
+@click.option("--server", "-s", "server_name", help="Named server from servers.toml")
+@click.option("--task", "task_id", help="Task ID (alias for TASK_ID)")
+@click.option(
+    "--config-id", "-c", required=True, help="Push notification config ID to remove"
+)
+@click.option(
+    "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
+)
+@click.option(
+    "--api-key-env", "-k", help="Env var containing API key (overrides saved)"
+)
+def notification_remove(
+    task_id_arg: Optional[str],
+    agent_url: Optional[str],
+    server_name: Optional[str],
+    task_id: Optional[str],
+    config_id: str,
+    bearer_env: Optional[str],
+    api_key_env: Optional[str],
+) -> None:
+    """Remove a push notification config from a task.
+
+    \b
+    Examples:
+      $ handler task notification remove task-123 --server my_agent --config-id cfg-1
+      $ handler task notification remove --url http://localhost:8000 --task task-123 --config-id cfg-1
+    """
+    output = Output()
+    task_id = require_task_id(resolve_task_id(task_id_arg, task_id))
+
+    selection = resolve_agent_selection(agent_url, server_name)
+    resolved_url = selection.agent_url
+
+    try:
+        validate_agent_url(resolved_url)
+        validate_resource_id(task_id, "task_id")
+        validate_resource_id(config_id, "config_id")
+    except InputValidationError as error:
+        handle_validation_error(error, output)
+        raise click.Abort() from error
+
+    log.info(
+        "Removing push config %s for task %s at %s", config_id, task_id, resolved_url
+    )
+
+    credentials = resolve_selection_credentials(selection, bearer_env, api_key_env)
+
+    async def do_remove() -> None:
+        try:
+            async with build_http_client(credentials=credentials) as http_client:
+                service = A2AService(http_client, resolved_url, credentials=credentials)
+
+                await service.delete_push_config(task_id, config_id)
+                if output.is_structured:
+                    output.json(
+                        {"deleted": True, "task_id": task_id, "config_id": config_id}
+                    )
+                else:
+                    output.text(f"Removed push config {config_id} from {task_id}.")
+
+        except Exception as e:
+            handle_client_error(e, resolved_url, output)
+            raise click.Abort()
+
+    asyncio.run(do_remove())
+
+
 @task_notification.command("get")
 @click.argument("task_id_arg", metavar="[TASK_ID]", required=False)
 @click.option("--url", "agent_url", help="Agent URL")

--- a/src/a2a_handler/mcp/server.py
+++ b/src/a2a_handler/mcp/server.py
@@ -650,6 +650,123 @@ def create_mcp_server() -> FastMCP:
             return push_config_dump(config)
 
     @mcp.tool()
+    async def list_task_notifications(
+        agent_url: str,
+        task_id: str,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+        cert_path: str | None = None,
+        key_path: str | None = None,
+        ca_cert_path: str | None = None,
+        custom_headers: dict[str, str] | None = None,
+    ) -> dict:
+        """List every push notification config for a task.
+
+        Follows pagination to the end, so the result is the complete set of
+        webhook configurations registered for the task.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - count: Number of configs returned
+            - configs: The configs with webhook tokens truncated for security
+        """
+        logger.info("Listing push configs for task %s at %s", task_id, agent_url)
+        try:
+            validate_agent_url(agent_url)
+            validate_resource_id(task_id, "task_id")
+            if bearer_token:
+                reject_control_chars(bearer_token, "bearer_token")
+            if api_key:
+                reject_control_chars(api_key, "api_key")
+        except InputValidationError as error:
+            raise _validation_error(error) from error
+
+        credentials = _resolve_credentials(
+            agent_url,
+            bearer_token,
+            api_key,
+            cert_path,
+            key_path,
+            ca_cert_path,
+            custom_headers,
+        )
+
+        async with _build_http_client(credentials=credentials) as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            configs = await service.list_all_push_configs(task_id)
+
+            return {
+                "count": len(configs),
+                "configs": [push_config_dump(config) for config in configs],
+            }
+
+    @mcp.tool()
+    async def delete_task_notification(
+        agent_url: str,
+        task_id: str,
+        config_id: str,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+        cert_path: str | None = None,
+        key_path: str | None = None,
+        ca_cert_path: str | None = None,
+        custom_headers: dict[str, str] | None = None,
+    ) -> dict:
+        """Delete a push notification config from a task.
+
+        Removes a webhook configuration so it no longer receives task updates.
+        Fails with the server's error if the config does not exist.
+
+        Args:
+            agent_url: Base URL of the A2A agent
+            task_id: ID of the task
+            config_id: ID of the config to delete
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
+
+        Returns:
+            A dictionary containing:
+            - deleted: True once the server confirmed the deletion
+            - task_id: The task ID
+            - config_id: The removed config ID
+        """
+        logger.info(
+            "Deleting push config %s for task %s at %s", config_id, task_id, agent_url
+        )
+        try:
+            validate_agent_url(agent_url)
+            validate_resource_id(task_id, "task_id")
+            validate_resource_id(config_id, "config_id")
+            if bearer_token:
+                reject_control_chars(bearer_token, "bearer_token")
+            if api_key:
+                reject_control_chars(api_key, "api_key")
+        except InputValidationError as error:
+            raise _validation_error(error) from error
+
+        credentials = _resolve_credentials(
+            agent_url,
+            bearer_token,
+            api_key,
+            cert_path,
+            key_path,
+            ca_cert_path,
+            custom_headers,
+        )
+
+        async with _build_http_client(credentials=credentials) as http_client:
+            service = A2AService(http_client, agent_url, credentials=credentials)
+            await service.delete_push_config(task_id, config_id)
+
+            return {"deleted": True, "task_id": task_id, "config_id": config_id}
+
+    @mcp.tool()
     async def list_sessions() -> dict:
         """List all saved sessions.
 

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 
 import httpx
 from a2a.client import A2ACardResolver, Client, ClientConfig, ClientFactory
-from a2a.client.errors import AgentCardResolutionError
+from a2a.client.errors import A2AClientError, AgentCardResolutionError
 from a2a.helpers import (
     get_data_parts,
     get_text_parts,
@@ -29,8 +29,11 @@ from a2a.helpers import (
 from a2a.types import (
     AgentCard,
     CancelTaskRequest,
+    DeleteTaskPushNotificationConfigRequest,
     GetTaskPushNotificationConfigRequest,
     GetTaskRequest,
+    ListTaskPushNotificationConfigsRequest,
+    ListTaskPushNotificationConfigsResponse,
     ListTasksRequest,
     ListTasksResponse,
     Message,
@@ -82,6 +85,23 @@ class TaskListing:
 
     tasks: list[Task]
     truncated: bool = False
+
+
+# Configs fetched per ListTaskPushNotificationConfigs request when the caller
+# does not choose a page size. Unlike ListTasksRequest.page_size, this field
+# has no explicit presence, so an omitted value is indistinguishable on the
+# wire from a literal zero. Sending a real default avoids depending on how a
+# given server reads that zero.
+DEFAULT_PUSH_CONFIG_PAGE_SIZE = 50
+
+
+class PushConfigNotFoundError(A2AClientError):
+    """Raised when a push config to delete does not exist on the task.
+
+    Servers commonly treat deletes as idempotent and report success for a
+    config that was never there, so Handler checks first: a mistyped config ID
+    should fail loudly, not read as a successful removal.
+    """
 
 
 TERMINAL_TASK_STATES = {
@@ -1103,3 +1123,99 @@ class A2AService:
         logger.info("Getting push config for task %s", task_id)
 
         return await client.get_task_push_notification_config(request)
+
+    async def list_push_configs(
+        self,
+        task_id: str,
+        page_size: int | None = None,
+        page_token: str | None = None,
+    ) -> ListTaskPushNotificationConfigsResponse:
+        """List a task's push notification configs, one page at a time.
+
+        Args:
+            task_id: ID of the task
+            page_size: Maximum configs per page (server may return fewer);
+                defaults to ``DEFAULT_PUSH_CONFIG_PAGE_SIZE``
+            page_token: Continuation token from a previous page's
+                ``next_page_token``
+
+        Returns:
+            The raw response with configs and the next page token.
+        """
+        validate_resource_id(task_id, "task_id")
+        if page_token:
+            reject_control_chars(page_token, "page_token")
+
+        client = await self._get_or_create_client()
+
+        # An unset proto3 int is indistinguishable from 0, and servers reject a
+        # zero page size, so always send an explicit one.
+        request = ListTaskPushNotificationConfigsRequest(
+            task_id=task_id,
+            page_size=page_size or DEFAULT_PUSH_CONFIG_PAGE_SIZE,
+            page_token=page_token or "",
+        )
+        logger.info("Listing push configs for task %s", task_id)
+
+        return await client.list_task_push_notification_configs(request)
+
+    async def list_all_push_configs(
+        self,
+        task_id: str,
+        page_size: int | None = None,
+    ) -> list[TaskPushNotificationConfig]:
+        """List a task's push configs across every page.
+
+        A repeated token stops the loop, so a server that keeps returning the
+        same page cannot spin this forever.
+        """
+        configs: list[TaskPushNotificationConfig] = []
+        page_token: str | None = None
+        seen_tokens: set[str] = set()
+
+        while True:
+            response = await self.list_push_configs(
+                task_id,
+                page_size=page_size,
+                page_token=page_token,
+            )
+            configs.extend(response.configs)
+            page_token = response.next_page_token
+            if not page_token or page_token in seen_tokens:
+                break
+            seen_tokens.add(page_token)
+
+        logger.info("Listed %d push config(s) for task %s", len(configs), task_id)
+        return configs
+
+    async def delete_push_config(self, task_id: str, config_id: str) -> None:
+        """Delete a push notification config from a task.
+
+        The config is listed first: servers commonly accept a delete for a
+        config that never existed, and that silence would hide a mistyped ID.
+
+        Args:
+            task_id: ID of the task
+            config_id: ID of the config to delete
+
+        Raises:
+            PushConfigNotFoundError: If no such config exists on the task.
+        """
+        validate_resource_id(task_id, "task_id")
+        validate_resource_id(config_id, "config_id")
+
+        existing = await self.list_all_push_configs(task_id)
+        if all(config.id != config_id for config in existing):
+            raise PushConfigNotFoundError(
+                f"Task {task_id} has no push notification config '{config_id}'"
+            )
+
+        client = await self._get_or_create_client()
+
+        request = DeleteTaskPushNotificationConfigRequest(
+            task_id=task_id,
+            id=config_id,
+        )
+        logger.info("Deleting push config %s for task %s", config_id, task_id)
+
+        await client.delete_task_push_notification_config(request)

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -813,6 +813,152 @@ class TestTaskNotificationSet:
         assert "Missing option" in result.output or "required" in result.output.lower()
 
 
+class TestTaskNotificationList:
+    """Tests for task notification list command."""
+
+    def test_notification_list_success(self, runner):
+        """Listing shows every config with tokens redacted."""
+        configs = [
+            make_push_config(
+                task_id="task-123",
+                url="http://webhook.example.com/a",
+                token="secret-token",
+                config_id="cfg-1",
+            ),
+            make_push_config(
+                task_id="task-123",
+                url="http://webhook.example.com/b",
+                config_id="cfg-2",
+            ),
+        ]
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.list_all_push_configs.return_value = configs
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "list",
+                    "task-123",
+                    "--url",
+                    "http://localhost:8000",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "cfg-1" in result.output
+            assert "cfg-2" in result.output
+            assert "secret-token" not in result.output
+            mock_service.list_all_push_configs.assert_called_once_with(
+                "task-123", page_size=None
+            )
+
+    def test_notification_list_requires_task_id(self, runner):
+        """Listing without a task ID fails before any network call."""
+        result = runner.invoke(
+            task,
+            ["notification", "list", "--url", "http://localhost:8000"],
+        )
+        assert result.exit_code != 0
+
+
+class TestTaskNotificationRemove:
+    """Tests for task notification remove command."""
+
+    def test_notification_remove_success(self, runner):
+        """Removing reports what was deleted."""
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.delete_push_config.return_value = None
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "remove",
+                    "task-123",
+                    "--url",
+                    "http://localhost:8000",
+                    "--config-id",
+                    "cfg-1",
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "cfg-1" in result.output
+            mock_service.delete_push_config.assert_called_once_with("task-123", "cfg-1")
+
+    def test_notification_remove_requires_config_id(self, runner):
+        """Removing without a config ID fails before any network call."""
+        result = runner.invoke(
+            task,
+            [
+                "notification",
+                "remove",
+                "task-123",
+                "--url",
+                "http://localhost:8000",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "config-id" in result.output.lower()
+
+    def test_notification_remove_surfaces_server_error(self, runner):
+        """A missing config fails loudly with the server's message."""
+        from a2a.client.errors import A2AClientError
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.delete_push_config.side_effect = A2AClientError(
+                "config not found"
+            )
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "remove",
+                    "task-123",
+                    "--url",
+                    "http://localhost:8000",
+                    "--config-id",
+                    "cfg-missing",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "config not found" in result.output
+
+
 class TestTaskNotificationGet:
     """Tests for task notification get command."""
 

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 from a2a.types import (
+    ListTaskPushNotificationConfigsResponse,
     ListTasksResponse,
     Message,
     Part,
@@ -22,6 +23,7 @@ from a2a_handler.common.input_validation import InputValidationError
 from a2a_handler.service import (
     A2AService,
     MAX_INLINE_FILE_BYTES,
+    PushConfigNotFoundError,
     StreamEvent,
     TASK_STATE_LABELS,
     TERMINAL_TASK_STATES,
@@ -829,6 +831,121 @@ class _FakePushConfigClient:
     async def create_task_push_notification_config(self, push_config):
         self.push_config = push_config
         return push_config
+
+
+class _FakePushConfigListDeleteClient:
+    """Replays list pages and records delete requests."""
+
+    def __init__(self, pages: list[ListTaskPushNotificationConfigsResponse]) -> None:
+        self.pages = pages
+        self.list_requests: list[Any] = []
+        self.delete_requests: list[Any] = []
+
+    async def list_task_push_notification_configs(self, request):
+        self.list_requests.append(request)
+        index = min(len(self.list_requests) - 1, len(self.pages) - 1)
+        return self.pages[index]
+
+    async def delete_task_push_notification_config(self, request):
+        self.delete_requests.append(request)
+        return None
+
+
+@pytest.mark.asyncio
+class TestA2AServicePushConfigListDelete:
+    """Tests for list_push_configs, list_all_push_configs, delete_push_config."""
+
+    def _service_with(self, fake_client: _FakePushConfigListDeleteClient) -> A2AService:
+        service = A2AService(
+            http_client=cast(httpx.AsyncClient, AsyncMock()),
+            agent_url="http://example.com",
+        )
+
+        async def _get_client():
+            return fake_client
+
+        service._get_or_create_client = _get_client  # type: ignore[method-assign]
+        return service
+
+    async def test_list_push_configs_builds_request(self):
+        page = ListTaskPushNotificationConfigsResponse(
+            configs=[make_push_config(task_id="task-1")]
+        )
+        fake_client = _FakePushConfigListDeleteClient([page])
+        service = self._service_with(fake_client)
+
+        response = await service.list_push_configs("task-1", page_size=5)
+
+        assert len(response.configs) == 1
+        request = fake_client.list_requests[0]
+        assert request.task_id == "task-1"
+        assert request.page_size == 5
+
+    async def test_list_push_configs_sends_nonzero_default_page_size(self):
+        fake_client = _FakePushConfigListDeleteClient(
+            [ListTaskPushNotificationConfigsResponse()]
+        )
+        service = self._service_with(fake_client)
+
+        await service.list_push_configs("task-1")
+
+        assert fake_client.list_requests[0].page_size > 0
+
+    async def test_list_push_configs_rejects_bad_task_id(self):
+        service = self._service_with(
+            _FakePushConfigListDeleteClient([ListTaskPushNotificationConfigsResponse()])
+        )
+        with pytest.raises(InputValidationError):
+            await service.list_push_configs("task?bad")
+
+    async def test_list_all_push_configs_follows_pages(self):
+        pages = [
+            ListTaskPushNotificationConfigsResponse(
+                configs=[make_push_config(task_id="task-1", config_id="cfg-1")],
+                next_page_token="page-2",
+            ),
+            ListTaskPushNotificationConfigsResponse(
+                configs=[make_push_config(task_id="task-1", config_id="cfg-2")],
+            ),
+        ]
+        fake_client = _FakePushConfigListDeleteClient(pages)
+        service = self._service_with(fake_client)
+
+        configs = await service.list_all_push_configs("task-1")
+
+        assert [config.id for config in configs] == ["cfg-1", "cfg-2"]
+        assert fake_client.list_requests[1].page_token == "page-2"
+
+    async def test_delete_push_config_sends_ids(self):
+        page = ListTaskPushNotificationConfigsResponse(
+            configs=[make_push_config(task_id="task-1", config_id="cfg-1")]
+        )
+        fake_client = _FakePushConfigListDeleteClient([page])
+        service = self._service_with(fake_client)
+
+        await service.delete_push_config("task-1", "cfg-1")
+
+        request = fake_client.delete_requests[0]
+        assert request.task_id == "task-1"
+        assert request.id == "cfg-1"
+
+    async def test_delete_push_config_fails_loudly_for_missing_config(self):
+        # Servers accept deletes for configs that never existed; Handler
+        # must not report that as a successful removal.
+        fake_client = _FakePushConfigListDeleteClient(
+            [ListTaskPushNotificationConfigsResponse()]
+        )
+        service = self._service_with(fake_client)
+
+        with pytest.raises(PushConfigNotFoundError):
+            await service.delete_push_config("task-1", "cfg-missing")
+
+        assert fake_client.delete_requests == []
+
+    async def test_delete_push_config_rejects_bad_config_id(self):
+        service = self._service_with(_FakePushConfigListDeleteClient([]))
+        with pytest.raises(InputValidationError):
+            await service.delete_push_config("task-1", "cfg?bad")
 
 
 class _FakeGetPushConfigClient:

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -70,6 +70,8 @@ def test_mcp_server_registers_core_tools() -> None:
     assert "get_task" in names
     assert "list_tasks" in names
     assert "set_task_notification" in names
+    assert "list_task_notifications" in names
+    assert "delete_task_notification" in names
     assert "list_sessions" in names
 
 
@@ -547,6 +549,79 @@ async def test_get_task_notification_success() -> None:
     assert resp["url"] == "https://hooks.example.com/notify"
     assert resp["token"] == "abcd...0xyz"
     assert resp["id"] == "cfg-2"
+
+
+# ---------------------------------------------------------------------------
+# list_task_notifications / delete_task_notification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_task_notifications_success() -> None:
+    server = create_mcp_server()
+    fn = _tool_fn(server, "list_task_notifications")
+
+    configs = [
+        make_push_config(
+            task_id="task-1",
+            url="http://webhook.example.com",
+            token="secret-token-value",
+            config_id="cfg-1",
+        )
+    ]
+
+    mock_service = AsyncMock()
+    mock_service.list_all_push_configs.return_value = configs
+
+    with (
+        patch("a2a_handler.mcp.server._build_http_client", return_value=_mock_http()),
+        patch("a2a_handler.mcp.server.A2AService", return_value=mock_service),
+    ):
+        resp = await fn(agent_url="http://localhost:8000", task_id="task-1")
+
+    assert resp["count"] == 1
+    assert resp["configs"][0]["id"] == "cfg-1"
+    assert resp["configs"][0]["token"] != "secret-token-value"
+
+
+@pytest.mark.asyncio
+async def test_list_task_notifications_rejects_invalid_task_id() -> None:
+    server = create_mcp_server()
+    fn = _tool_fn(server, "list_task_notifications")
+
+    with pytest.raises(ValueError, match="invalid_control_chars"):
+        await fn(agent_url="http://localhost:8000", task_id="bad\x00id")
+
+
+@pytest.mark.asyncio
+async def test_delete_task_notification_success() -> None:
+    server = create_mcp_server()
+    fn = _tool_fn(server, "delete_task_notification")
+
+    mock_service = AsyncMock()
+    mock_service.delete_push_config.return_value = None
+
+    with (
+        patch("a2a_handler.mcp.server._build_http_client", return_value=_mock_http()),
+        patch("a2a_handler.mcp.server.A2AService", return_value=mock_service),
+    ):
+        resp = await fn(
+            agent_url="http://localhost:8000", task_id="task-1", config_id="cfg-1"
+        )
+
+    assert resp == {"deleted": True, "task_id": "task-1", "config_id": "cfg-1"}
+    mock_service.delete_push_config.assert_called_once_with("task-1", "cfg-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_task_notification_rejects_invalid_config_id() -> None:
+    server = create_mcp_server()
+    fn = _tool_fn(server, "delete_task_notification")
+
+    with pytest.raises(ValueError, match="invalid_resource_id"):
+        await fn(
+            agent_url="http://localhost:8000", task_id="task-1", config_id="cfg?bad"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #102

Two of the four push-notification config methods were missing, so a config could be created but never listed or removed.

## Service layer

- `list_push_configs(task_id, ...)` — one page, raw `ListTaskPushNotificationConfigsResponse`
- `list_all_push_configs(task_id)` — follows `next_page_token` with a repeated-token guard; always sends an explicit page size (servers reject the unset/zero value)
- `delete_push_config(task_id, config_id)` — deletes, but **lists first** and raises `PushConfigNotFoundError` when the config is not there

That last point is a deliberate design decision worth review: the ADK server (like many) treats deletes as idempotent and reports success for a config that never existed, which would silently swallow a mistyped ID. The acceptance criterion says removal of a nonexistent config must fail clearly, so Handler checks client-side. Cost: one extra request per delete.

## CLI

- `handler task notification list [TASK_ID]` — full listing with webhook tokens redacted (`push_config_dump`)
- `handler task notification remove [TASK_ID] --config-id ID` — reports what was deleted; structured output in json mode

## MCP

`list_task_notifications` and `delete_task_notification` tools, matching the two existing notification tools in shape and auth arguments.

## Verification

- 472 tests pass; ruff/ty clean
- Verified live against an ADK test-agent variant with push notifications enabled: a config was created, listed (token redacted), and removed in one session; the list was empty afterwards; and removing a nonexistent config failed with `Task ... has no push notification config 'does-not-exist'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)