### PR TITLE
feat: implement GetExtendedAgentCard

### DIFF
--- a/src/a2a_handler/cli/card.py
+++ b/src/a2a_handler/cli/card.py
@@ -36,6 +36,11 @@ def card() -> None:
 @click.option("--url", "agent_url", help="Agent URL")
 @click.option("--server", "-s", "server_name", help="Named server from servers.toml")
 @click.option(
+    "--extended",
+    is_flag=True,
+    help="Fetch the extended card offered to authenticated clients",
+)
+@click.option(
     "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
 )
 @click.option(
@@ -44,6 +49,7 @@ def card() -> None:
 def card_get(
     agent_url: Optional[str],
     server_name: Optional[str],
+    extended: bool,
     bearer_env: Optional[str],
     api_key_env: Optional[str],
 ) -> None:
@@ -54,6 +60,7 @@ def card_get(
       $ handler card get --server my_agent
       $ handler card get --url http://localhost:8000
       $ handler card get --url http://localhost:8000 --bearer-env MY_TOKEN
+      $ handler card get --url http://localhost:8000 --extended --bearer-env MY_TOKEN
     """
     output = Output()
 
@@ -74,7 +81,10 @@ def card_get(
         try:
             async with build_http_client(credentials=credentials) as http_client:
                 service = A2AService(http_client, resolved_url, credentials=credentials)
-                card_data = await service.get_card()
+                if extended:
+                    card_data = await service.get_extended_card()
+                else:
+                    card_data = await service.get_card()
                 log.info("Retrieved card for agent: %s", card_data.name)
 
                 _format_agent_card(card_data, output)

--- a/src/a2a_handler/mcp/server.py
+++ b/src/a2a_handler/mcp/server.py
@@ -205,7 +205,16 @@ def create_mcp_server() -> FastMCP:
         return response
 
     @mcp.tool()
-    async def get_agent_card(agent_url: str) -> dict:
+    async def get_agent_card(
+        agent_url: str,
+        extended: bool = False,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+        cert_path: str | None = None,
+        key_path: str | None = None,
+        ca_cert_path: str | None = None,
+        custom_headers: dict[str, str] | None = None,
+    ) -> dict:
         """Retrieve an agent's card with full details.
 
         Fetches the agent card from the specified A2A agent URL. The agent card
@@ -214,6 +223,11 @@ def create_mcp_server() -> FastMCP:
 
         Args:
             agent_url: Base URL of the A2A agent (e.g., "http://localhost:8000")
+            extended: If True, fetch the extended card agents offer to
+                     authenticated clients. Fails clearly when the agent does
+                     not offer one.
+            bearer_token: Optional bearer token for authentication
+            api_key: Optional API key for authentication
 
         Returns:
             The agent card as a dictionary with all available fields.
@@ -221,14 +235,29 @@ def create_mcp_server() -> FastMCP:
         logger.info("Getting agent card from %s", agent_url)
         try:
             validate_agent_url(agent_url)
+            if bearer_token:
+                reject_control_chars(bearer_token, "bearer_token")
+            if api_key:
+                reject_control_chars(api_key, "api_key")
         except InputValidationError as error:
             raise _validation_error(error) from error
 
-        credentials = _resolve_credentials(agent_url)
+        credentials = _resolve_credentials(
+            agent_url,
+            bearer_token,
+            api_key,
+            cert_path,
+            key_path,
+            ca_cert_path,
+            custom_headers,
+        )
 
         async with _build_http_client(credentials=credentials) as http_client:
             service = A2AService(http_client, agent_url, credentials=credentials)
-            card = await service.get_card()
+            if extended:
+                card = await service.get_extended_card()
+            else:
+                card = await service.get_card()
 
             return to_json_dict(card)
 

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -30,6 +30,7 @@ from a2a.types import (
     AgentCard,
     CancelTaskRequest,
     DeleteTaskPushNotificationConfigRequest,
+    GetExtendedAgentCardRequest,
     GetTaskPushNotificationConfigRequest,
     GetTaskRequest,
     ListTaskPushNotificationConfigsRequest,
@@ -49,6 +50,7 @@ from a2a.types import (
     TaskStatusUpdateEvent,
 )
 from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH, TransportProtocol
+from a2a.utils.errors import ExtendedAgentCardNotConfiguredError
 from google.protobuf import json_format
 
 from a2a_handler.auth import AuthCredentials, AuthType
@@ -101,6 +103,15 @@ class PushConfigNotFoundError(A2AClientError):
     Servers commonly treat deletes as idempotent and report success for a
     config that was never there, so Handler checks first: a mistyped config ID
     should fail loudly, not read as a successful removal.
+    """
+
+
+class ExtendedCardNotSupportedError(A2AClientError):
+    """Raised when an extended agent card is requested but not on offer.
+
+    Covers both the agent whose public card never advertised one and the
+    server that advertises support yet has no extended card configured, so
+    callers get one clear message instead of a raw protocol error.
     """
 
 
@@ -732,6 +743,43 @@ class A2AService:
         """
         await self.ensure_oauth2_token()
         return await self._load_agent_card()
+
+    @property
+    def supports_extended_card(self) -> bool:
+        """Whether the fetched public card advertises an extended card."""
+        if self._cached_agent_card:
+            return bool(self._cached_agent_card.capabilities.extended_agent_card)
+        return False
+
+    async def get_extended_card(self) -> AgentCard:
+        """Fetch the extended agent card offered to authenticated clients.
+
+        Returns:
+            The extended card, which may reveal skills or interfaces the
+            public card omits.
+
+        Raises:
+            ExtendedCardNotSupportedError: If the agent's public card does not
+                advertise ``extended_agent_card``, or the server has no
+                extended card configured despite advertising one.
+        """
+        card = await self.get_card()
+        if not card.capabilities.extended_agent_card:
+            raise ExtendedCardNotSupportedError(
+                f"{card.name or self.agent_url} does not offer an extended "
+                "agent card (capabilities.extendedAgentCard is not set)"
+            )
+
+        client = await self._get_or_create_client()
+        logger.info("Fetching extended agent card from %s", self.agent_url)
+        try:
+            return await client.get_extended_agent_card(GetExtendedAgentCardRequest())
+        except ExtendedAgentCardNotConfiguredError as exc:
+            # The card advertised support but the server has nothing to serve.
+            raise ExtendedCardNotSupportedError(
+                f"{card.name or self.agent_url} advertises an extended agent "
+                "card but the server has none configured"
+            ) from exc
 
     async def _get_or_create_client(self) -> Client:
         """Get or create the A2A client.

--- a/src/a2a_handler/tui/server/tab.py
+++ b/src/a2a_handler/tui/server/tab.py
@@ -497,6 +497,31 @@ class ServerTab(Container):
         self._agent_service = next_service
         return agent_card
 
+    async def _maybe_fetch_extended_card(
+        self,
+        agent_card: AgentCard,
+    ) -> tuple[AgentCard, str | None]:
+        """Swap in the extended card when the agent offers one.
+
+        A failed fetch keeps the public card and reports why, rather than
+        failing the connection over an optional detail.
+        """
+        if (
+            not agent_card.capabilities.extended_agent_card
+            or self._agent_service is None
+        ):
+            return agent_card, None
+        try:
+            extended_card = await self._agent_service.get_extended_card()
+        except Exception as error:  # noqa: BLE001 - reported to the user, not raised
+            logger.warning(
+                "Extended card fetch failed for %s: %s", self.server_id, error
+            )
+            return agent_card, (
+                f"The agent offers an extended card, but fetching it failed: {error}"
+            )
+        return extended_card, "Showing the agent's extended card."
+
     async def _apply_connected_ui(
         self,
         conversation_summary: str,
@@ -604,6 +629,9 @@ class ServerTab(Container):
             credentials = messages_panel.get_auth_credentials()
 
             agent_card = await self._connect_to_agent(agent_url, credentials)
+            agent_card, extended_note = await self._maybe_fetch_extended_card(
+                agent_card
+            )
             context_id: str | None = None
             resumed_task_id: str | None = None
             if saved_conversation is not None:
@@ -626,6 +654,8 @@ class ServerTab(Container):
                 ),
                 saved_conversation=saved_conversation,
             )
+            if extended_note:
+                messages_panel.add_system_message(extended_note)
             self._persist_session_state()
             self.post_message(self.TitleChanged(self.server_id, agent_card.name))
 

--- a/tests/cli/test_card.py
+++ b/tests/cli/test_card.py
@@ -70,6 +70,59 @@ class TestCardGet:
             assert "Test Agent" in result.output
             assert "test_skill" in result.output
 
+    def test_card_get_extended_success(self, runner):
+        """--extended fetches the extended card instead of the public one."""
+        extended_card = make_agent_card(name="Extended Agent")
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_extended_card.return_value = extended_card
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                card, ["get", "--url", "http://localhost:8000", "--extended"]
+            )
+
+            assert result.exit_code == 0
+            assert "Extended Agent" in result.output
+            mock_service.get_extended_card.assert_called_once_with()
+            mock_service.get_card.assert_not_called()
+
+    def test_card_get_extended_unsupported_fails_clearly(self, runner):
+        """An agent without an extended card yields a clear message."""
+        from a2a_handler.service import ExtendedCardNotSupportedError
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_extended_card.side_effect = ExtendedCardNotSupportedError(
+                "Test Agent does not offer an extended agent card"
+            )
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                card, ["get", "--url", "http://localhost:8000", "--extended"]
+            )
+
+            assert result.exit_code != 0
+            assert "does not offer an extended agent card" in result.output
+            assert "Traceback" not in result.output
+
     def test_card_get_connection_error(self, runner):
         """Test card get handles connection errors."""
         import httpx

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 from a2a.types import (
+    AgentCard,
     ListTaskPushNotificationConfigsResponse,
     ListTasksResponse,
     Message,
@@ -20,8 +21,10 @@ from typing import Any, cast
 
 from a2a_handler.auth import create_bearer_auth, create_oauth2_auth
 from a2a_handler.common.input_validation import InputValidationError
+from a2a.utils.errors import ExtendedAgentCardNotConfiguredError
 from a2a_handler.service import (
     A2AService,
+    ExtendedCardNotSupportedError,
     MAX_INLINE_FILE_BYTES,
     PushConfigNotFoundError,
     StreamEvent,
@@ -1364,3 +1367,82 @@ class TestA2AServiceOAuthAndCards:
             response = await http_client.get("/ping")
 
         assert response.status_code == 200
+
+
+class _FakeExtendedCardClient:
+    """Returns (or raises) for get_extended_agent_card, recording calls."""
+
+    def __init__(self, result: AgentCard | Exception) -> None:
+        self.result = result
+        self.calls = 0
+
+    async def get_extended_agent_card(self, request, **_kwargs):
+        self.calls += 1
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+@pytest.mark.asyncio
+class TestA2AServiceExtendedCard:
+    """Tests for A2AService.get_extended_card."""
+
+    def _service_with(
+        self,
+        public_card: AgentCard,
+        fake_client: _FakeExtendedCardClient,
+    ) -> A2AService:
+        service = A2AService(
+            http_client=cast(httpx.AsyncClient, AsyncMock()),
+            agent_url="http://example.com",
+        )
+        service._cached_agent_card = public_card
+
+        async def _get_client():
+            return fake_client
+
+        service._get_or_create_client = _get_client  # type: ignore[method-assign]
+        return service
+
+    async def test_extended_card_returned_when_offered(self):
+        public_card = make_agent_card(name="Public", extended_agent_card=True)
+        extended_card = make_agent_card(name="Extended", extended_agent_card=True)
+        fake_client = _FakeExtendedCardClient(extended_card)
+        service = self._service_with(public_card, fake_client)
+
+        card = await service.get_extended_card()
+
+        assert card.name == "Extended"
+        assert fake_client.calls == 1
+
+    async def test_refused_when_card_does_not_advertise_support(self):
+        public_card = make_agent_card(name="Public", extended_agent_card=False)
+        fake_client = _FakeExtendedCardClient(make_agent_card())
+        service = self._service_with(public_card, fake_client)
+
+        with pytest.raises(ExtendedCardNotSupportedError) as exc_info:
+            await service.get_extended_card()
+
+        assert "Public" in str(exc_info.value)
+        assert fake_client.calls == 0
+
+    async def test_server_not_configured_error_is_translated(self):
+        public_card = make_agent_card(name="Public", extended_agent_card=True)
+        fake_client = _FakeExtendedCardClient(
+            ExtendedAgentCardNotConfiguredError("raw protocol error")
+        )
+        service = self._service_with(public_card, fake_client)
+
+        with pytest.raises(ExtendedCardNotSupportedError) as exc_info:
+            await service.get_extended_card()
+
+        assert "none configured" in str(exc_info.value)
+
+    async def test_supports_extended_card_property(self):
+        service = A2AService(
+            http_client=cast(httpx.AsyncClient, AsyncMock()),
+            agent_url="http://example.com",
+        )
+        assert service.supports_extended_card is False
+        service._cached_agent_card = make_agent_card(extended_agent_card=True)
+        assert service.supports_extended_card is True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -201,11 +201,20 @@ def make_agent_card(
     protocol_version: str = "1.0",
     streaming: bool = True,
     push_notifications: bool = False,
+    extended_agent_card: bool = False,
     skills: Sequence[AgentSkill] | None = None,
     default_input_modes: Sequence[str] = ("text",),
     default_output_modes: Sequence[str] = ("text",),
 ) -> AgentCard:
     """Build a v1.0 ``AgentCard`` with a single JSON-RPC interface."""
+    capabilities = AgentCapabilities(
+        streaming=streaming,
+        push_notifications=push_notifications,
+    )
+    # Capability fields carry explicit presence; setting False would surface
+    # "extendedAgentCard": false in card renders that never showed it.
+    if extended_agent_card:
+        capabilities.extended_agent_card = True
     return AgentCard(
         name=name,
         description=description,
@@ -217,10 +226,7 @@ def make_agent_card(
                 protocol_version=protocol_version,
             )
         ],
-        capabilities=AgentCapabilities(
-            streaming=streaming,
-            push_notifications=push_notifications,
-        ),
+        capabilities=capabilities,
         default_input_modes=list(default_input_modes),
         default_output_modes=list(default_output_modes),
         skills=list(skills) if skills is not None else [],

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -161,6 +161,48 @@ async def test_get_agent_card_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_agent_card_extended() -> None:
+    server = create_mcp_server()
+    fn = _tool_fn(server, "get_agent_card")
+
+    extended_card = _make_agent_card(name="ExtendedAgent")
+    mock_service = AsyncMock()
+    mock_service.get_extended_card.return_value = extended_card
+
+    with (
+        patch("a2a_handler.mcp.server._build_http_client", return_value=_mock_http()),
+        patch("a2a_handler.mcp.server.A2AService", return_value=mock_service),
+    ):
+        resp = await fn(agent_url="http://localhost:8000", extended=True)
+
+    assert resp["name"] == "ExtendedAgent"
+    mock_service.get_extended_card.assert_called_once_with()
+    mock_service.get_card.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_card_extended_unsupported_raises_clear_error() -> None:
+    from a2a_handler.service import ExtendedCardNotSupportedError
+
+    server = create_mcp_server()
+    fn = _tool_fn(server, "get_agent_card")
+
+    mock_service = AsyncMock()
+    mock_service.get_extended_card.side_effect = ExtendedCardNotSupportedError(
+        "TestAgent does not offer an extended agent card"
+    )
+
+    with (
+        patch("a2a_handler.mcp.server._build_http_client", return_value=_mock_http()),
+        patch("a2a_handler.mcp.server.A2AService", return_value=mock_service),
+    ):
+        with pytest.raises(
+            ExtendedCardNotSupportedError, match="does not offer an extended"
+        ):
+            await fn(agent_url="http://localhost:8000", extended=True)
+
+
+@pytest.mark.asyncio
 async def test_get_agent_card_rejects_invalid_url() -> None:
     server = create_mcp_server()
     fn = _tool_fn(server, "get_agent_card")

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -1300,6 +1300,95 @@ async def test_connect_manual_override_uses_manual_credentials() -> None:
 
 
 @pytest.mark.asyncio
+async def test_connect_shows_extended_card_when_offered() -> None:
+    """A card advertising extended support is swapped for the extended card."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    new_http_client = AsyncMock()
+    public_card = make_agent_card(name="Public Agent", extended_agent_card=True)
+    extended_card = make_agent_card(name="Extended Agent", extended_agent_card=True)
+
+    with (
+        patch(
+            "a2a_handler.tui.server.tab.load_server_catalog",
+            return_value=ServerCatalog(repository_servers=(repo_connection,)),
+        ),
+        patch(
+            "a2a_handler.tui.server.tab.build_http_client",
+            return_value=new_http_client,
+        ),
+        patch("a2a_handler.tui.server.tab.A2AService") as mock_service_cls,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = public_card
+        mock_service.get_extended_card.return_value = extended_card
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            assert workspace.is_connected
+            assert workspace.state.agent_card is not None
+            assert workspace.state.agent_card.name == "Extended Agent"
+            chat_texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any(
+                "Showing the agent's extended card" in text for text in chat_texts
+            )
+
+
+async def test_connect_keeps_public_card_when_extended_fetch_fails() -> None:
+    """A failed extended-card fetch keeps the connection and the public card."""
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    new_http_client = AsyncMock()
+    public_card = make_agent_card(name="Public Agent", extended_agent_card=True)
+
+    with (
+        patch(
+            "a2a_handler.tui.server.tab.load_server_catalog",
+            return_value=ServerCatalog(repository_servers=(repo_connection,)),
+        ),
+        patch(
+            "a2a_handler.tui.server.tab.build_http_client",
+            return_value=new_http_client,
+        ),
+        patch("a2a_handler.tui.server.tab.A2AService") as mock_service_cls,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = public_card
+        mock_service.get_extended_card.side_effect = RuntimeError("card fetch broke")
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            assert workspace.is_connected
+            assert workspace.state.agent_card is not None
+            assert workspace.state.agent_card.name == "Public Agent"
+            chat_texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any("fetching it failed" in text for text in chat_texts)
+
+
 async def test_connect_transitions_server_to_live_view_and_updates_tab_title() -> None:
     """Successful connect should update the unified server view and tab title."""
     repo_connection = _make_server(


### PR DESCRIPTION
Closes #103

`GetExtendedAgentCard` is in the A2A v1.0 spec and Handler implemented it nowhere, so agents that reveal additional skills or interfaces only to authenticated clients could not be fully inspected.

## Service layer

- `A2AService.get_extended_card()` fetches the extended card via the SDK
- Both failure shapes surface as one clear `ExtendedCardNotSupportedError` instead of a raw protocol error:
  - the public card does not advertise `capabilities.extendedAgentCard` (refused up front, no request made)
  - the card advertises support but the server has none configured (the SDK's `ExtendedAgentCardNotConfiguredError` is translated)
- `supports_extended_card` property mirrors the existing capability accessors

## CLI

`handler card get --extended` — returns the extended card when offered; otherwise a clear one-line message (no traceback).

## TUI

On connect, an agent advertising an extended card gets it fetched and shown in the card panel, with a "Showing the agent's extended card." note. A failed fetch keeps the public card and the connection, reporting why — an optional detail never fails the connect.

## MCP

`get_agent_card` takes an `extended` argument, and now also accepts the same auth arguments as the other tools (bearer/api key/mTLS/custom headers) — extended cards are typically credential-gated and the tool previously had no way to pass credentials at all.

## Test infrastructure

`make_agent_card` grew an `extended_agent_card` flag. Capability fields carry explicit presence in the proto, so the factory only sets the field when true — otherwise `"extendedAgentCard": false` would surface in card renders (and snapshots) that never showed it.

## Verification

- 466 tests pass; ruff/ty clean
- Verified live: a local test agent wired with a real extended card (extra hidden skill) returns it via `card get --extended`; the streaming agent without one yields `streaming_test_agent does not offer an extended agent card (capabilities.extendedAgentCard is not set)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)