### PR TITLE
feat: support A2A extensions

### DIFF
--- a/src/a2a_handler/cli/message.py
+++ b/src/a2a_handler/cli/message.py
@@ -110,6 +110,13 @@ def message() -> None:
 @click.option("--push-url", help="Webhook URL for push notifications")
 @click.option("--push-token", help="Authentication token for push notifications")
 @click.option(
+    "--extension",
+    "-e",
+    "extensions",
+    multiple=True,
+    help="A2A extension URI to request (repeatable)",
+)
+@click.option(
     "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
 )
 @click.option(
@@ -138,6 +145,7 @@ def message_send(
     no_wait: bool,
     push_url: Optional[str],
     push_token: Optional[str],
+    extensions: tuple[str, ...],
     bearer_env: Optional[str],
     api_key_env: Optional[str],
     headers: tuple[str, ...] = (),
@@ -241,6 +249,8 @@ def message_send(
             reject_control_chars(push_token, "push_token")
         for output_mode in accepted_output_modes:
             reject_control_chars(output_mode, "accept")
+        for extension_uri in extensions:
+            reject_control_chars(extension_uri, "extension")
         if no_wait and stream:
             raise InputValidationError(
                 code="conflicting_options",
@@ -255,6 +265,14 @@ def message_send(
         raise click.Abort() from error
 
     message_text = text or ""
+
+    # Per-server configured extensions apply first; flags add to them.
+    requested_extensions: list[str] = []
+    if selection.server_def is not None:
+        requested_extensions.extend(selection.server_def.extensions)
+    for extension_uri in extensions:
+        if extension_uri not in requested_extensions:
+            requested_extensions.append(extension_uri)
 
     log.info("Sending message to %s", resolved_url)
 
@@ -309,6 +327,7 @@ def message_send(
                     push_notification_url=push_url,
                     push_notification_token=push_token,
                     credentials=credentials,
+                    extensions=requested_extensions or None,
                 )
 
                 if stream:
@@ -409,6 +428,13 @@ def _build_attachments(
 @click.option("--push-url", help="Webhook URL for push notifications")
 @click.option("--push-token", help="Authentication token for push notifications")
 @click.option(
+    "--extension",
+    "-e",
+    "extensions",
+    multiple=True,
+    help="A2A extension URI to request (repeatable)",
+)
+@click.option(
     "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
 )
 @click.option(
@@ -436,6 +462,7 @@ def message_stream(
     history_length: Optional[int],
     push_url: Optional[str],
     push_token: Optional[str],
+    extensions: tuple[str, ...],
     bearer_env: Optional[str],
     api_key_env: Optional[str],
     headers: tuple[str, ...] = (),
@@ -465,6 +492,7 @@ def message_stream(
         no_wait=False,
         push_url=push_url,
         push_token=push_token,
+        extensions=extensions,
         bearer_env=bearer_env,
         api_key_env=api_key_env,
         headers=headers,

--- a/src/a2a_handler/servers.py
+++ b/src/a2a_handler/servers.py
@@ -84,6 +84,8 @@ class ServerDefinition:
     agent_url: str
     auth: ServerAuthConfig | None = None
     origin_label: str = ""
+    #: A2A extension URIs to request on every call to this server.
+    extensions: tuple[str, ...] = ()
 
     @property
     def label(self) -> str:
@@ -472,6 +474,10 @@ def _parse_server(
     if "auth" in server_table:
         auth = _parse_server_auth(server_table.get("auth"))
 
+    extensions: tuple[str, ...] = ()
+    if "extensions" in server_table:
+        extensions = _parse_server_extensions(server_table.get("extensions"))
+
     return ServerDefinition(
         server_id=f"{source.value}:{name}",
         source=source,
@@ -479,7 +485,26 @@ def _parse_server(
         agent_url=raw_url,
         auth=auth,
         origin_label=server_source_label(source),
+        extensions=extensions,
     )
+
+
+def _parse_server_extensions(extensions_data: object) -> tuple[str, ...]:
+    """Validate a server's requested A2A extension URI list."""
+    if not isinstance(extensions_data, list) or not all(
+        isinstance(uri, str) for uri in extensions_data
+    ):
+        raise ServerConfigError("extensions must be a list of strings")
+    validated: list[str] = []
+    for uri in extensions_data:
+        if not isinstance(uri, str) or not uri.strip():
+            raise ServerConfigError("extensions entries must be non-empty strings")
+        try:
+            reject_control_chars(uri, "extensions")
+        except InputValidationError as error:
+            raise ServerConfigError(error.message) from error
+        validated.append(uri.strip())
+    return tuple(validated)
 
 
 def _parse_server_auth(auth_data: object) -> ServerAuthConfig:

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -50,6 +50,7 @@ from a2a.types import (
     TaskState,
     TaskStatusUpdateEvent,
 )
+from a2a.extensions.common import HTTP_EXTENSION_HEADER
 from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH, TransportProtocol
 from a2a.utils.errors import ExtendedAgentCardNotConfiguredError
 from google.protobuf import json_format
@@ -273,6 +274,20 @@ def role_label(role: int | None) -> str:
     if not role:
         return "unknown"
     return Role.Name(role).removeprefix("ROLE_").lower()
+
+
+def card_extensions(card: AgentCard) -> list[dict[str, Any]]:
+    """Return the extensions a card declares, in A2A wire format."""
+    return [to_json_dict(extension) for extension in card.capabilities.extensions]
+
+
+def required_extension_uris(card: AgentCard) -> list[str]:
+    """Return the URIs of extensions the card marks as required."""
+    return [
+        extension.uri
+        for extension in card.capabilities.extensions
+        if extension.required and extension.uri
+    ]
 
 
 def card_protocol_version(card: AgentCard) -> str:
@@ -684,6 +699,7 @@ class A2AService:
         push_notification_url: str | None = None,
         push_notification_token: str | None = None,
         credentials: AuthCredentials | None = None,
+        extensions: Iterable[str] | None = None,
     ) -> None:
         """Initialize the A2A service.
 
@@ -694,6 +710,8 @@ class A2AService:
             push_notification_url: Optional webhook URL for push notifications
             push_notification_token: Optional token for push notification auth
             credentials: Optional authentication credentials
+            extensions: Optional A2A extension URIs to request on every call
+                (sent as the ``A2A-Extensions`` header)
         """
         validate_agent_url(agent_url)
         if push_notification_url:
@@ -701,15 +719,27 @@ class A2AService:
         if push_notification_token:
             reject_control_chars(push_notification_token, "push_notification_token")
 
+        requested_extensions: list[str] = []
+        for extension_uri in extensions or ():
+            reject_control_chars(extension_uri, "extension")
+            stripped = extension_uri.strip()
+            if stripped:
+                requested_extensions.append(stripped)
+
         self.http_client = http_client
         self.agent_url = agent_url
         self.enable_streaming = enable_streaming
         self.push_notification_url = push_notification_url
         self.push_notification_token = push_notification_token
         self.credentials = credentials
+        self.extensions: tuple[str, ...] = tuple(requested_extensions)
         self._cached_client: Client | None = None
         self._cached_agent_card: AgentCard | None = None
         self._applied_auth_headers: set[str] = set()
+
+        if self.extensions:
+            self.http_client.headers[HTTP_EXTENSION_HEADER] = ", ".join(self.extensions)
+            logger.info("Requesting A2A extensions: %s", ", ".join(self.extensions))
 
         if credentials:
             self.set_credentials(credentials)
@@ -802,7 +832,24 @@ class A2AService:
                 )
                 self._cached_agent_card = await fallback_resolver.get_agent_card()
             logger.info("Connected to agent: %s", self._cached_agent_card.name)
+            missing = self.unrequested_required_extensions(self._cached_agent_card)
+            if missing:
+                logger.warning(
+                    "Agent %s requires extension(s) this client did not request: %s",
+                    self._cached_agent_card.name,
+                    ", ".join(missing),
+                )
         return self._cached_agent_card
+
+    def unrequested_required_extensions(self, card: AgentCard) -> list[str]:
+        """Return required extension URIs the client is not requesting.
+
+        An agent that marks an extension required may refuse or degrade
+        requests without it, so this is worth surfacing to the user.
+        """
+        return [
+            uri for uri in required_extension_uris(card) if uri not in self.extensions
+        ]
 
     async def get_card(self) -> AgentCard:
         """Fetch and cache the agent card.

--- a/src/a2a_handler/tui/server/tab.py
+++ b/src/a2a_handler/tui/server/tab.py
@@ -35,6 +35,7 @@ from a2a_handler.service import (
     card_protocol_version,
     extract_text_from_message_parts,
     part_file,
+    required_extension_uris,
     response_task_id,
     response_state,
     state_label,
@@ -477,6 +478,7 @@ class ServerTab(Container):
         self,
         agent_url: str,
         credentials: AuthCredentials | None,
+        extensions: tuple[str, ...] = (),
     ) -> AgentCard:
         previous_http_client = self.http_client
         previous_service = self._agent_service
@@ -486,6 +488,7 @@ class ServerTab(Container):
             next_http_client,
             agent_url,
             credentials=credentials,
+            extensions=extensions or None,
         )
         try:
             agent_card = await next_service.get_card()
@@ -635,7 +638,13 @@ class ServerTab(Container):
         try:
             credentials = messages_panel.get_auth_credentials()
 
-            agent_card = await self._connect_to_agent(agent_url, credentials)
+            agent_card = await self._connect_to_agent(
+                agent_url,
+                credentials,
+                extensions=(
+                    selected_server.extensions if selected_server is not None else ()
+                ),
+            )
             agent_card, extended_note = await self._maybe_fetch_extended_card(
                 agent_card
             )
@@ -663,6 +672,19 @@ class ServerTab(Container):
             )
             if extended_note:
                 messages_panel.add_system_message(extended_note)
+            requested_extensions = (
+                selected_server.extensions if selected_server is not None else ()
+            )
+            missing_extensions = [
+                uri
+                for uri in required_extension_uris(agent_card)
+                if uri not in requested_extensions
+            ]
+            if missing_extensions:
+                messages_panel.add_system_message(
+                    "This agent requires A2A extension(s) Handler did not "
+                    "request: " + ", ".join(missing_extensions)
+                )
             self._persist_session_state()
             self.post_message(self.TitleChanged(self.server_id, agent_card.name))
 

--- a/tests/cli/test_card.py
+++ b/tests/cli/test_card.py
@@ -9,7 +9,7 @@ from unittest.mock import patch as mock_patch
 
 import pytest
 from click.testing import CliRunner
-from a2a.types import AgentCard, AgentSkill
+from a2a.types import AgentCard, AgentExtension, AgentSkill
 
 from a2a_handler.cli import cli
 from a2a_handler.cli.card import card, _format_agent_card, _format_validation_result
@@ -414,3 +414,36 @@ class TestFormatValidationResult:
         call_args = output.json.call_args[0][0]
         assert call_args["valid"] is False
         assert len(call_args["issues"]) == 1
+
+    def test_card_get_shows_declared_extensions(self, runner):
+        """Extensions the card declares are visible in the output."""
+
+        mock_card = make_agent_card(
+            name="Extended Agent",
+            extensions=[
+                AgentExtension(
+                    uri="https://ext.example.com/traceability/v1",
+                    description="Traceability",
+                    required=True,
+                )
+            ],
+        )
+
+        with (
+            patch("a2a_handler.cli.card.build_http_client") as mock_client,
+            patch("a2a_handler.cli.card.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_card.return_value = mock_card
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(card, ["get", "--url", "http://localhost:8000"])
+
+            assert result.exit_code == 0
+            assert "https://ext.example.com/traceability/v1" in result.output
+            assert '"required": true' in result.output

--- a/tests/cli/test_message.py
+++ b/tests/cli/test_message.py
@@ -582,6 +582,72 @@ class TestMessageSend:
         assert result.exit_code != 0
         assert "Cannot read file" in result.output
 
+    def test_message_send_with_extensions(self, runner):
+        """--extension URIs reach the service so they land on the wire."""
+        mock_task = _make_task(TaskState.TASK_STATE_COMPLETED, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_task
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                [
+                    "send",
+                    "--url",
+                    "http://localhost:8000",
+                    "--text",
+                    "Hello",
+                    "--extension",
+                    "https://ext.example.com/traceability/v1",
+                    "--extension",
+                    "urn:x:custom",
+                ],
+            )
+
+            assert result.exit_code == 0
+            call_kwargs = mock_service_cls.call_args.kwargs
+            assert call_kwargs["extensions"] == [
+                "https://ext.example.com/traceability/v1",
+                "urn:x:custom",
+            ]
+
+    def test_message_send_without_extensions_passes_none(self, runner):
+        """No extension flags means no A2A-Extensions header is requested."""
+        mock_task = _make_task(TaskState.TASK_STATE_COMPLETED, text="Response")
+
+        with (
+            patch("a2a_handler.cli.message.build_http_client") as mock_client,
+            patch("a2a_handler.cli.message.A2AService") as mock_service_cls,
+            patch("a2a_handler.cli.message.update_session"),
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.send.return_value = mock_task
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                message,
+                ["send", "--url", "http://localhost:8000", "--text", "Hello"],
+            )
+
+            assert result.exit_code == 0
+            assert mock_service_cls.call_args.kwargs["extensions"] is None
+
     def test_message_send_json_requires_text(self, runner):
         """Test message send fails when text is missing in both argument and json."""
         result = runner.invoke(

--- a/tests/config/test_servers.py
+++ b/tests/config/test_servers.py
@@ -699,3 +699,54 @@ def test_resolve_oidc_warns_when_client_id_env_missing(
     assert credentials is None
     assert warning is not None
     assert "SSO_CLIENT_ID" in warning
+
+
+def test_load_servers_parses_extensions(tmp_path: Path) -> None:
+    """Per-server extension URIs load in declaration order."""
+    server_path = tmp_path / "servers.toml"
+    server_path.write_text(
+        """
+version = 1
+
+[servers.traced]
+url = "https://traced.example.com/agent"
+extensions = ["https://ext.example.com/traceability/v1", "urn:x:custom"]
+""".strip()
+    )
+    servers = load_servers(tmp_path, ServerSource.GLOBAL)
+    assert len(servers) == 1
+    assert servers[0].extensions == (
+        "https://ext.example.com/traceability/v1",
+        "urn:x:custom",
+    )
+
+
+def test_load_servers_defaults_to_no_extensions(tmp_path: Path) -> None:
+    """Servers without an extensions key request none."""
+    server_path = tmp_path / "servers.toml"
+    server_path.write_text(
+        """
+version = 1
+
+[servers.plain]
+url = "https://plain.example.com/agent"
+""".strip()
+    )
+    servers = load_servers(tmp_path, ServerSource.GLOBAL)
+    assert servers[0].extensions == ()
+
+
+def test_load_servers_skips_invalid_extensions(tmp_path: Path) -> None:
+    """A non-list extensions value invalidates the server entry."""
+    server_path = tmp_path / "servers.toml"
+    server_path.write_text(
+        """
+version = 1
+
+[servers.broken]
+url = "https://broken.example.com/agent"
+extensions = "not-a-list"
+""".strip()
+    )
+    servers = load_servers(tmp_path, ServerSource.GLOBAL)
+    assert servers == []

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from a2a.types import (
     AgentCard,
+    AgentExtension,
     ListTaskPushNotificationConfigsResponse,
     ListTasksResponse,
     Message,
@@ -32,6 +33,7 @@ from a2a_handler.service import (
     TERMINAL_TASK_STATES,
     TransportNegotiationError,
     attachment_part_from_spec,
+    card_extensions,
     build_data_part,
     build_file_part,
     build_url_part,
@@ -1632,3 +1634,83 @@ class TestA2AServiceTransportSelection:
 
         assert "CARRIER-PIGEON" in str(exc_info.value)
         assert "a2a-handler[grpc]" not in str(exc_info.value)
+
+
+class TestExtensions:
+    """Tests for A2A extension requesting and card inspection."""
+
+    def _http_client(self) -> AsyncMock:
+        http_client = AsyncMock()
+        http_client.headers = {}
+        return http_client
+
+    def test_requested_extensions_land_on_the_header(self):
+        http_client = self._http_client()
+        service = A2AService(
+            http_client=cast(httpx.AsyncClient, http_client),
+            agent_url="http://example.com",
+            extensions=["https://ext.example.com/traceability/v1", "urn:x:custom"],
+        )
+
+        assert service.extensions == (
+            "https://ext.example.com/traceability/v1",
+            "urn:x:custom",
+        )
+        assert http_client.headers["A2A-Extensions"] == (
+            "https://ext.example.com/traceability/v1, urn:x:custom"
+        )
+
+    def test_no_extensions_means_no_header(self):
+        http_client = self._http_client()
+        A2AService(
+            http_client=cast(httpx.AsyncClient, http_client),
+            agent_url="http://example.com",
+        )
+        assert "A2A-Extensions" not in http_client.headers
+
+    def test_extension_uris_reject_control_chars(self):
+        with pytest.raises(InputValidationError):
+            A2AService(
+                http_client=cast(httpx.AsyncClient, self._http_client()),
+                agent_url="http://example.com",
+                extensions=["bad\x00uri"],
+            )
+
+    def test_card_extensions_returns_wire_format(self):
+        card = make_agent_card(
+            extensions=[
+                AgentExtension(
+                    uri="https://ext.example.com/traceability/v1",
+                    description="Traceability",
+                    required=True,
+                )
+            ]
+        )
+        extensions = card_extensions(card)
+        assert extensions == [
+            {
+                "uri": "https://ext.example.com/traceability/v1",
+                "description": "Traceability",
+                "required": True,
+            }
+        ]
+
+    def test_unrequested_required_extensions_flags_the_gap(self):
+        card = make_agent_card(
+            extensions=[
+                AgentExtension(uri="urn:required-ext", required=True),
+                AgentExtension(uri="urn:optional-ext"),
+            ]
+        )
+        service = A2AService(
+            http_client=cast(httpx.AsyncClient, self._http_client()),
+            agent_url="http://example.com",
+        )
+        assert service.unrequested_required_extensions(card) == ["urn:required-ext"]
+
+        requesting = A2AService(
+            http_client=cast(httpx.AsyncClient, self._http_client()),
+            agent_url="http://example.com",
+            extensions=["urn:required-ext"],
+        )
+        assert requesting.unrequested_required_extensions(card) == []

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,6 +22,7 @@ from a2a import helpers
 from a2a.types import (
     AgentCapabilities,
     AgentCard,
+    AgentExtension,
     AgentInterface,
     AgentSkill,
     Artifact,
@@ -203,6 +204,7 @@ def make_agent_card(
     streaming: bool = True,
     push_notifications: bool = False,
     extended_agent_card: bool = False,
+    extensions: Sequence[AgentExtension] | None = None,
     skills: Sequence[AgentSkill] | None = None,
     default_input_modes: Sequence[str] = ("text",),
     default_output_modes: Sequence[str] = ("text",),
@@ -216,6 +218,8 @@ def make_agent_card(
     # "extendedAgentCard": false in card renders that never showed it.
     if extended_agent_card:
         capabilities.extended_agent_card = True
+    if extensions:
+        capabilities.extensions.extend(extensions)
     return AgentCard(
         name=name,
         description=description,

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 import pytest
 from a2a.client.errors import A2AClientError
 from a2a.types import (
+    AgentExtension,
     Message,
     Part,
     Role,
@@ -565,6 +566,7 @@ async def test_auto_connected_oauth2_server_populates_auth_panel(
         http_client: AsyncMock,
         agent_url: str,
         credentials: object | None = None,
+        extensions: object | None = None,
     ) -> AsyncMock:
         connected_credentials[agent_url] = credentials
         service = AsyncMock()
@@ -1466,6 +1468,7 @@ async def test_connect_transitions_server_to_live_view_and_updates_tab_title() -
                 new_http_client,
                 "https://agent.example.com",
                 credentials=None,
+                extensions=None,
             )
 
 
@@ -2753,3 +2756,48 @@ async def test_connect_shows_negotiated_transport_badge() -> None:
             transport_badge = workspace.query_one("#badge-transport", Static)
             assert not transport_badge.has_class("hidden")
             assert "HTTP+JSON" in str(transport_badge.content)
+
+
+@pytest.mark.asyncio
+async def test_connect_warns_about_unrequested_required_extensions() -> None:
+    """A required extension Handler did not request is surfaced on connect."""
+
+    repo_connection = _make_server(
+        source=ServerSource.REPOSITORY,
+        name="demo",
+        agent_url="https://agent.example.com",
+    )
+    app = HandlerTUI()
+    new_http_client = AsyncMock()
+    mock_card = make_agent_card(
+        name="Demo Agent",
+        extensions=[AgentExtension(uri="urn:required-ext", required=True)],
+    )
+
+    with (
+        patch(
+            "a2a_handler.tui.server.tab.load_server_catalog",
+            return_value=ServerCatalog(repository_servers=(repo_connection,)),
+        ),
+        patch(
+            "a2a_handler.tui.server.tab.build_http_client",
+            return_value=new_http_client,
+        ),
+        patch("a2a_handler.tui.server.tab.A2AService") as mock_service_cls,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_card.return_value = mock_card
+        mock_service_cls.return_value = mock_service
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            workspace = app.query_one(ServerTabs).get_active_server()
+            assert workspace is not None
+
+            await workspace.handle_connect_button()
+            await pilot.pause()
+
+            assert workspace.is_connected
+            chat_texts = _chat_texts(workspace.query_one(TabbedMessagesPanel))
+            assert any("urn:required-ext" in text for text in chat_texts)

--- a/tests/tui/test_snapshots.py
+++ b/tests/tui/test_snapshots.py
@@ -282,7 +282,7 @@ def test_handler_tui_connected_snapshot(snap_compare, monkeypatch: pytest.Monkey
         local_patch.setattr(
             tab_module,
             "A2AService",
-            lambda http_client, agent_url, credentials=None: AsyncMock(
+            lambda http_client, agent_url, credentials=None, extensions=None: AsyncMock(
                 get_card=AsyncMock(return_value=_make_agent_card())
             ),
         )
@@ -323,7 +323,7 @@ async def test_handler_tui_tasks_tab_shows_task_details(
         local_patch.setattr(
             tab_module,
             "A2AService",
-            lambda http_client, agent_url, credentials=None: AsyncMock(
+            lambda http_client, agent_url, credentials=None, extensions=None: AsyncMock(
                 get_card=AsyncMock(return_value=_make_agent_card())
             ),
         )
@@ -380,7 +380,7 @@ async def test_handler_tui_artifacts_tab_shows_artifact_details(
         local_patch.setattr(
             tab_module,
             "A2AService",
-            lambda http_client, agent_url, credentials=None: AsyncMock(
+            lambda http_client, agent_url, credentials=None, extensions=None: AsyncMock(
                 get_card=AsyncMock(return_value=_make_agent_card())
             ),
         )


### PR DESCRIPTION
Closes #107

Handler was blind to A2A extensions: it never sent the `A2A-Extensions` header and did nothing with `AgentExtension` declarations on the card.

## Requesting extensions

- `A2AService` accepts an `extensions` list of URIs and sends them as the `A2A-Extensions` header on every request (using the SDK's `HTTP_EXTENSION_HEADER` constant); URIs are validated and stripped
- CLI: repeatable `--extension`/`-e` on `message send` and `message stream`
- Config: a per-server `extensions = ["uri", ...]` list in servers.toml (top-level on the server table, shaped like #82's custom headers will be). Configured extensions apply automatically; CLI flags merge on top. The TUI applies a selected server's configured extensions on connect.

## Seeing declared extensions

- `card_extensions(card)` and `required_extension_uris(card)` expose card declarations
- Declared extensions were already visible in `card get` output and the TUI card panel via the full card dump; tests now pin that down so it cannot silently regress

## Warning on required extensions (the "decide whether" item)

Decided: warn, but only for extensions the card marks `required` and the client is not requesting — an agent may refuse or degrade without them, while unrequested *optional* extensions are normal and stay quiet.

- Logged as a warning when the card is first fetched (CLI and everywhere else)
- Shown as a system message in the TUI on connect: "This agent requires A2A extension(s) Handler did not request: ..."

## Verification

- 468 tests pass; ruff/ty clean
- Wire-verified with a capture server — the request carries:
  `A2A-Extensions: https://ext.example.com/traceability/v1, urn:x:custom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)