### PR TITLE
docs: add guide for testing Handler against a youagent A2A server

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,7 +52,8 @@
               "guides/mcp",
               "guides/agent-docs-mcp",
               "guides/enterprise-a2a",
-              "guides/local-servers"
+              "guides/local-servers",
+              "guides/youagent"
             ]
           }
         ]

--- a/docs/guides/youagent.mdx
+++ b/docs/guides/youagent.mdx
@@ -1,44 +1,90 @@
 ---
 title: "Test against youagent"
-description: "Point Handler at a youagent instance for a quick, real-world A2A interoperability check."
+description: "Run a real local A2A agent with youagent and exercise Handler's card, message, and server commands against it."
 ---
 
 # Test Handler against a youagent agent
 
 Handler needs an A2A server to talk to. If you do not have one handy, you can
 run a [youagent](https://github.com/brainsparker/youagent) instance locally in
-about two minutes. youagent is an MIT-licensed, CLI-first agent framework
+a couple of minutes. youagent is an MIT-licensed, CLI-first agent framework
 whose agents expose a standard A2A server: card discovery at
 `/.well-known/agent.json`, a health endpoint, and JSON-RPC 2.0 `message/send`,
 `tasks/get`, and `tasks/cancel`.
 
 This gives you a real, independently implemented A2A server for
 interoperability checks, demos, and client development, with no API keys
-required.
+required. Requires Node 20+.
 
-## Start a youagent A2A server
+## Start a local agent
 
-youagent requires Node 20+.
+Install the published package and create a small server script:
 
 ```bash
-git clone https://github.com/brainsparker/youagent
-cd youagent
-npm install
-npm run build
-npx tsx examples/a2a-server.ts
+mkdir youagent-demo && cd youagent-demo
+npm install youagent
 ```
 
-The example agent listens on `http://localhost:3141` and logs its card URL on
-startup. No search or network credentials are needed to serve the A2A
-endpoints.
+```javascript serve.mjs
+import { createAgentCard, A2AServer } from "youagent";
 
-## Inspect the agent card
+const card = createAgentCard({
+  handle: "demo-agent",
+  displayName: "Demo Agent",
+  interests: [{ topic: "a2a interoperability" }],
+  cadence: "6h",
+  url: "http://localhost:3141",
+});
+
+// Handler's client (the a2a SDK) requires protocol version 0.3 or newer;
+// youagent 0.0.2 stamps cards with 0.2.1, so bump it before serving.
+card.protocolVersion = "0.3.0";
+
+const server = new A2AServer({ agentCard: card, port: 3141 });
+
+server.registerYouAgentHandlers({
+  onMessage: async (message) => ({
+    role: "agent",
+    messageId: crypto.randomUUID(),
+    parts: [
+      {
+        type: "text",
+        text: `Demo Agent received: ${
+          // Spec 0.3+ clients (Handler included) send parts keyed by "kind";
+          // youagent's own client sends "type". Accept both.
+          message.parts.find((part) => part.type === "text" || part.kind === "text")
+            ?.text ?? "(no text)"
+        }`,
+      },
+    ],
+  }),
+});
+
+await server.start();
+console.log("A2A server listening on http://localhost:3141");
+```
+
+```bash
+node serve.mjs
+```
+
+The server exposes:
+
+- `GET /.well-known/agent.json` for card discovery (also `/agent-card`)
+- `GET /health` for liveness checks
+- `POST /` for JSON-RPC: `message/send`, `tasks/get`, `tasks/cancel`
+
+## Inspect and validate the card
 
 ```bash
 handler card get --url http://localhost:3141
 ```
 
-You should see a standard A2A agent card. youagent cards may also carry an
+```bash
+handler card validate --url http://localhost:3141
+```
+
+You should see a standard A2A agent card. youagent cards also carry an
 optional `youagent` extension block with identity, interests, and search
 cadence. Handler renders the standard card fields either way, which is the
 point of the exercise: unknown extensions should not break a compliant client.
@@ -46,24 +92,40 @@ point of the exercise: unknown extensions should not break a compliant client.
 ## Send a message
 
 ```bash
-handler message send --url http://localhost:3141 --text "hello"
+handler message send --url http://localhost:3141 --text "Hello from Handler"
 ```
 
-The youagent server answers over JSON-RPC 2.0, so Handler's full message and
-task flow works against it like any other compliant A2A server.
+The agent responds with a completed task containing the echoed reply from the
+`onMessage` handler above. Structured output works as usual:
+
+```bash
+handler --output json message send --url http://localhost:3141 --text "ping"
+```
 
 ## Add it as a configured server
 
 If you test against youagent regularly, add it to your server config:
 
 ```bash
-handler server add youagent --url http://localhost:3141
+handler server add youagent-local --url http://localhost:3141
 ```
 
 Or repo-scoped, if an interop test setup should travel with your repository:
 
 ```bash
-handler server add youagent --url http://localhost:3141 --repository
+handler server add youagent-local --url http://localhost:3141 --repository
+```
+
+Then use the short form anywhere a server is accepted:
+
+```bash
+handler message send --server youagent-local --text "Hello again"
+```
+
+Or browse it interactively:
+
+```bash
+handler tui
 ```
 
 ## Health check
@@ -75,11 +137,13 @@ driving Handler at it:
 curl http://localhost:3141/health
 ```
 
-## Notes on social extensions
+## Notes
 
-youagent defines social extensions (`youagent/follow`, `youagent/unfollow`,
-`youagent/posts-request`) that travel as A2A `DataPart`s inside
-`message/send`. They are ordinary protocol traffic, so Handler can send them
-like any other message payload. A plain text message does not trigger them,
-and a youagent server responds to standard A2A requests without any extension
-awareness on the client side.
+- youagent's social extensions (`youagent/follow`, `youagent/unfollow`,
+  `youagent/posts-request`) travel as A2A `DataPart`s inside `message/send`,
+  so any A2A-compliant client can exercise them. A plain text message does not
+  trigger them. See the
+  [youagent README](https://github.com/brainsparker/youagent#a2a-protocol-support)
+  for the payload shapes.
+- The example server does not enforce the security schemes a card can declare,
+  so treat it as a development target, not a production deployment.

--- a/docs/guides/youagent.mdx
+++ b/docs/guides/youagent.mdx
@@ -1,0 +1,85 @@
+---
+title: "Test against youagent"
+description: "Point Handler at a youagent instance for a quick, real-world A2A interoperability check."
+---
+
+# Test Handler against a youagent agent
+
+Handler needs an A2A server to talk to. If you do not have one handy, you can
+run a [youagent](https://github.com/brainsparker/youagent) instance locally in
+about two minutes. youagent is an MIT-licensed, CLI-first agent framework
+whose agents expose a standard A2A server: card discovery at
+`/.well-known/agent.json`, a health endpoint, and JSON-RPC 2.0 `message/send`,
+`tasks/get`, and `tasks/cancel`.
+
+This gives you a real, independently implemented A2A server for
+interoperability checks, demos, and client development, with no API keys
+required.
+
+## Start a youagent A2A server
+
+youagent requires Node 20+.
+
+```bash
+git clone https://github.com/brainsparker/youagent
+cd youagent
+npm install
+npm run build
+npx tsx examples/a2a-server.ts
+```
+
+The example agent listens on `http://localhost:3141` and logs its card URL on
+startup. No search or network credentials are needed to serve the A2A
+endpoints.
+
+## Inspect the agent card
+
+```bash
+handler card get --url http://localhost:3141
+```
+
+You should see a standard A2A agent card. youagent cards may also carry an
+optional `youagent` extension block with identity, interests, and search
+cadence. Handler renders the standard card fields either way, which is the
+point of the exercise: unknown extensions should not break a compliant client.
+
+## Send a message
+
+```bash
+handler message send --url http://localhost:3141 --text "hello"
+```
+
+The youagent server answers over JSON-RPC 2.0, so Handler's full message and
+task flow works against it like any other compliant A2A server.
+
+## Add it as a configured server
+
+If you test against youagent regularly, add it to your server config:
+
+```bash
+handler server add youagent --url http://localhost:3141
+```
+
+Or repo-scoped, if an interop test setup should travel with your repository:
+
+```bash
+handler server add youagent --url http://localhost:3141 --repository
+```
+
+## Health check
+
+youagent also exposes a liveness endpoint you can use in scripts before
+driving Handler at it:
+
+```bash
+curl http://localhost:3141/health
+```
+
+## Notes on social extensions
+
+youagent defines social extensions (`youagent/follow`, `youagent/unfollow`,
+`youagent/posts-request`) that travel as A2A `DataPart`s inside
+`message/send`. They are ordinary protocol traffic, so Handler can send them
+like any other message payload. A plain text message does not trigger them,
+and a youagent server responds to standard A2A requests without any extension
+awareness on the client side.


### PR DESCRIPTION
Handler's quickstart now assumes you can point the client at an A2A server you already have (nice cleanup in #92, by the way). If you do not have one handy, this adds a short guide for running a real, independently implemented A2A server locally with youagent and driving Handler at it. Full disclosure: I maintain youagent.

Why it is useful here: youagent agents expose a standard A2A server (card discovery at /.well-known/agent.json, a health endpoint, and JSON-RPC 2.0 message/send, tasks/get, tasks/cancel), and the repo ships a runnable example server that needs no API keys. That gives Handler users a two-minute interop target for client development and demos.

What changed:
- New guide docs/guides/youagent.mdx covering: starting the youagent example server, handler card get, handler message send, adding it via handler server add (global and repo-scoped), the health endpoint, and a note on youagent's social extension DataParts.
- One nav entry in docs/docs.json under "Agent and MCP workflows", after local-servers.

Setup and env vars: none. The example server runs without credentials (Node 20+).

Usage example:
```
handler card get --url http://localhost:3141
handler message send --url http://localhost:3141 --text "hello"
```

Validation performed:
- python3 -m json.tool docs/docs.json passes.
- Ran the guide's youagent steps end to end: npm install, npm run build, npx tsx examples/a2a-server.ts, then verified GET /.well-known/agent.json serves the card, GET /health returns ok, and a JSON-RPC message/send POST returns a completed task.
- Not run, being honest: the handler CLI commands themselves (my validation environment is stuck on Python 3.9, below Handler's 3.11 floor) and a mint render of the new page. The two handler commands in the guide are copied from your quickstart and servers docs with only the URL changed.

Fallback and error handling: documentation only. No code paths, dependencies, or defaults change. If the youagent server is not running, Handler behaves exactly as with any unreachable server URL.

I kept this docs-only and matched the structure of the local-servers guide. Happy to move it in the nav, fold it into an existing page, or adjust the framing if you prefer. No hard feelings if third-party server guides are out of scope for the docs.

Tracking issue on my side: https://github.com/brainsparker/youagent/issues/4
