### PR TITLE
fix: stop sending an empty config id on notification get

### DIFF
--- a/src/a2a_handler/cli/task.py
+++ b/src/a2a_handler/cli/task.py
@@ -618,7 +618,11 @@ def notification_remove(
 @click.option("--url", "agent_url", help="Agent URL")
 @click.option("--server", "-s", "server_name", help="Named server from servers.toml")
 @click.option("--task", "task_id", help="Task ID (alias for TASK_ID)")
-@click.option("--config-id", "-c", help="Specific push notification config ID")
+@click.option(
+    "--config-id",
+    "-c",
+    help="Push notification config ID (required when the task has more than one)",
+)
 @click.option(
     "--bearer-env", "-b", help="Env var containing bearer token (overrides saved)"
 )

--- a/src/a2a_handler/mcp/server.py
+++ b/src/a2a_handler/mcp/server.py
@@ -638,7 +638,9 @@ def create_mcp_server() -> FastMCP:
         Args:
             agent_url: Base URL of the A2A agent
             task_id: ID of the task
-            config_id: Optional specific config ID to retrieve
+            config_id: Optional specific config ID. When omitted, the
+                task's only config is returned; several configs require
+                this ID so an empty string is never sent to the agent.
             bearer_token: Optional bearer token for authentication
             api_key: Optional API key for authentication
 

--- a/src/a2a_handler/service.py
+++ b/src/a2a_handler/service.py
@@ -104,11 +104,21 @@ DEFAULT_PUSH_CONFIG_PAGE_SIZE = 50
 
 
 class PushConfigNotFoundError(A2AClientError):
-    """Raised when a push config to delete does not exist on the task.
+    """Raised when a push config does not exist on the task.
 
-    Servers commonly treat deletes as idempotent and report success for a
-    config that was never there, so Handler checks first: a mistyped config ID
-    should fail loudly, not read as a successful removal.
+    Used when get has nothing to return, and when delete would otherwise look
+    successful: servers commonly treat deletes as idempotent, so Handler
+    checks first. A mistyped config ID should fail loudly, not read as a
+    successful removal.
+    """
+
+
+class PushConfigAmbiguousError(A2AClientError):
+    """Raised when a task has several push configs and none was chosen.
+
+    ``get_push_config`` without a config ID can only auto-select when the
+    task has exactly one config. Several configs need an explicit ID so
+    Handler never sends an empty string that servers reject as invalid.
     """
 
 
@@ -1400,22 +1410,47 @@ class A2AService:
     ) -> TaskPushNotificationConfig:
         """Get push notification configuration for a task.
 
+        An omitted ``config_id`` is not sent as an empty string: servers
+        reject that as ``InvalidParams``. The task's configs are listed
+        instead, and the single config is returned when there is exactly one.
+
         Args:
             task_id: ID of the task
             config_id: Optional specific config ID to retrieve
 
         Returns:
             The push notification configuration
+
+        Raises:
+            PushConfigNotFoundError: If the task has no push configs.
+            PushConfigAmbiguousError: If the task has several configs and
+                ``config_id`` was omitted.
         """
-        client = await self._get_or_create_client()
+        validate_resource_id(task_id, "task_id")
+        if config_id:
+            validate_resource_id(config_id, "config_id")
+            client = await self._get_or_create_client()
+            request = GetTaskPushNotificationConfigRequest(
+                task_id=task_id,
+                id=config_id,
+            )
+            logger.info("Getting push config %s for task %s", config_id, task_id)
+            return await client.get_task_push_notification_config(request)
 
-        request = GetTaskPushNotificationConfigRequest(
-            task_id=task_id,
-            id=config_id or "",
-        )
-        logger.info("Getting push config for task %s", task_id)
+        configs = await self.list_all_push_configs(task_id)
+        if not configs:
+            raise PushConfigNotFoundError(
+                f"Task {task_id} has no push notification config"
+            )
+        if len(configs) > 1:
+            ids = ", ".join(config.id or "(unnamed)" for config in configs)
+            raise PushConfigAmbiguousError(
+                f"Task {task_id} has {len(configs)} push notification configs "
+                f"({ids}); specify config_id to choose one"
+            )
 
-        return await client.get_task_push_notification_config(request)
+        logger.info("Getting the only push config for task %s", task_id)
+        return configs[0]
 
     async def list_push_configs(
         self,

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -1042,6 +1042,42 @@ class TestTaskNotificationGet:
                 "task-123", "specific-config-id"
             )
 
+    def test_notification_get_reports_ambiguous_configs(self, runner):
+        """Several configs without --config-id should fail locally, not on the server."""
+        from a2a_handler.service import PushConfigAmbiguousError
+
+        with (
+            patch("a2a_handler.cli.task.build_http_client") as mock_client,
+            patch("a2a_handler.cli.task.A2AService") as mock_service_cls,
+        ):
+            mock_http = AsyncMock()
+            mock_http.__aenter__.return_value = mock_http
+            mock_http.__aexit__.return_value = None
+            mock_client.return_value = mock_http
+
+            mock_service = AsyncMock()
+            mock_service.get_push_config.side_effect = PushConfigAmbiguousError(
+                "Task task-123 has 2 push notification configs "
+                "(cfg-1, cfg-2); specify config_id to choose one"
+            )
+            mock_service_cls.return_value = mock_service
+
+            result = runner.invoke(
+                task,
+                [
+                    "notification",
+                    "get",
+                    "--url",
+                    "http://localhost:8000",
+                    "--task",
+                    "task-123",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "cfg-1" in result.output
+            assert "specify config_id" in result.output
+
 
 class TestFormatTask:
     """Tests for _format_task helper."""

--- a/tests/core/test_service.py
+++ b/tests/core/test_service.py
@@ -27,6 +27,7 @@ from a2a_handler.service import (
     A2AService,
     ExtendedCardNotSupportedError,
     MAX_INLINE_FILE_BYTES,
+    PushConfigAmbiguousError,
     PushConfigNotFoundError,
     StreamEvent,
     TASK_STATE_LABELS,
@@ -925,17 +926,22 @@ class _FakePushConfigClient:
 
 
 class _FakePushConfigListDeleteClient:
-    """Replays list pages and records delete requests."""
+    """Replays list pages and records get/delete requests."""
 
     def __init__(self, pages: list[ListTaskPushNotificationConfigsResponse]) -> None:
         self.pages = pages
         self.list_requests: list[Any] = []
+        self.get_requests: list[Any] = []
         self.delete_requests: list[Any] = []
 
     async def list_task_push_notification_configs(self, request):
         self.list_requests.append(request)
         index = min(len(self.list_requests) - 1, len(self.pages) - 1)
         return self.pages[index]
+
+    async def get_task_push_notification_config(self, request):
+        self.get_requests.append(request)
+        raise AssertionError("get must not be called with an empty config id")
 
     async def delete_task_push_notification_config(self, request):
         self.delete_requests.append(request)
@@ -1037,6 +1043,47 @@ class TestA2AServicePushConfigListDelete:
         service = self._service_with(_FakePushConfigListDeleteClient([]))
         with pytest.raises(InputValidationError):
             await service.delete_push_config("task-1", "cfg?bad")
+
+    async def test_get_push_config_without_id_returns_the_only_config(self):
+        only = make_push_config(task_id="task-1", config_id="cfg-1")
+        fake_client = _FakePushConfigListDeleteClient(
+            [ListTaskPushNotificationConfigsResponse(configs=[only])]
+        )
+        service = self._service_with(fake_client)
+
+        result = await service.get_push_config("task-1")
+
+        assert result == only
+        assert fake_client.get_requests == []
+
+    async def test_get_push_config_without_id_errors_when_several_exist(self):
+        fake_client = _FakePushConfigListDeleteClient(
+            [
+                ListTaskPushNotificationConfigsResponse(
+                    configs=[
+                        make_push_config(task_id="task-1", config_id="cfg-1"),
+                        make_push_config(task_id="task-1", config_id="cfg-2"),
+                    ]
+                )
+            ]
+        )
+        service = self._service_with(fake_client)
+
+        with pytest.raises(PushConfigAmbiguousError, match="cfg-1"):
+            await service.get_push_config("task-1")
+
+        assert fake_client.get_requests == []
+
+    async def test_get_push_config_without_id_errors_when_none_exist(self):
+        fake_client = _FakePushConfigListDeleteClient(
+            [ListTaskPushNotificationConfigsResponse()]
+        )
+        service = self._service_with(fake_client)
+
+        with pytest.raises(PushConfigNotFoundError):
+            await service.get_push_config("task-1")
+
+        assert fake_client.get_requests == []
 
 
 class _FakeGetPushConfigClient:
@@ -1406,7 +1453,7 @@ class TestA2AServiceOAuthAndCards:
         assert service.supports_push_notifications is True
 
     async def test_get_push_config_passes_task_and_config_id_to_client(self) -> None:
-        """Push config lookup should preserve both the task ID and optional config ID."""
+        """An explicit config ID is sent as-is and never rewritten to empty."""
         expected = make_push_config(
             task_id="task-123",
             url="https://example.com/webhook",


### PR DESCRIPTION
## Summary
- `handler task notification get` without `--config-id` sent an empty string, which A2A servers reject as `InvalidParams` ([#121](https://github.com/alDuncanson/Handler/issues/121)).
- When the flag is omitted, list the task's configs and return the only one; error locally if there are none or several.
- Same behavior is shared by the CLI and the MCP `get_task_notification` tool.

## Test plan
- [x] `uv run pytest tests/core/test_service.py tests/cli/test_task.py tests/mcp/test_server.py`
- [x] `uv run pytest --ignore=tests/tui`
- [x] `uv run ruff check .` / `uv run ruff format --check` / `uv run ty check` on the touched files
- [ ] `handler task notification get --url <agent> --task <id>` against an agent with a single push config (no `--config-id`)
- [ ] Same command with two configs should fail locally asking for `config_id`
- [ ] `--config-id` still fetches that specific config

Fixes #121